### PR TITLE
Kill watchers on app close.

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -317,10 +317,12 @@ version = "0.0.0"
 dependencies = [
  "aw-datastore",
  "aw-server",
+ "nix",
  "serde",
  "serde_json",
  "tauri",
  "tauri-build",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -579,6 +581,12 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
 
 [[package]]
 name = "chrono"
@@ -2355,6 +2363,18 @@ name = "new_debug_unreachable"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
+
+[[package]]
+name = "nix"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab2156c4fce2f8df6c499cc1c763e4394b7482525bf2a9701c9d79d215f519e4"
+dependencies = [
+ "bitflags 2.5.0",
+ "cfg-if 1.0.0",
+ "cfg_aliases",
+ "libc",
+]
 
 [[package]]
 name = "nodrop"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -16,6 +16,10 @@ tauri-build = { version = "1.5.1", features = [] }
 tauri = { version = "1.6", features = ["shell-open", "system-tray"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+#[cfg(unix)]
+nix = { version = "0.28.0", features = ["process", "signal"] }
+#[cfg(windows)]
+winapi = { version = "0.3", features = ["winuser"] }
 aw-server = { git = "https://github.com/ActivityWatch/aw-server-rust.git", branch = "master" }
 aw-datastore = { git = "https://github.com/ActivityWatch/aw-server-rust.git", branch = "master" }
 

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -1,8 +1,8 @@
 fn main() {
-  let webui_var = std::env::var("AW_WEBUI_DIR");
-  
-  if let Err(_) = webui_var {
-    panic!("AW_WEBUI_DIR environment variable not set, Try running make");
-  }
-  tauri_build::build();
+    let webui_var = std::env::var("AW_WEBUI_DIR");
+
+    if let Err(_) = webui_var {
+        panic!("AW_WEBUI_DIR environment variable not set, Try running make");
+    }
+    tauri_build::build();
 }

--- a/src-tauri/src/manager.rs
+++ b/src-tauri/src/manager.rs
@@ -85,7 +85,7 @@ fn send_sigterm(pid: u32) -> Result<(), nix::Error> {
 }
 #[cfg(windows)]
 fn send_sigterm(pid: u32) -> Result<(), std::io::Error> {
-    let process_handle = unsafe { OpenProcess(PROCESS_TERMINATE, false, child_pid) };
+    let process_handle = unsafe { OpenProcess(PROCESS_TERMINATE, false, pid) };
 
     if process_handle == null_mut() {
         println!(


### PR DESCRIPTION
This took longer than I wished it did. Learnt so much about how rust handles concurrency. I experimented with using channels but that would not work because Rust does not allow for multiple receivers to the same channel. I came up with this solution. Does not use a condition variable though. It could be improved I'll revisit it later when I'm better at rust concurrency.

<!--
ELLIPSIS_HIDDEN
-->


----

| :rocket: This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 2d69626f966543f5eb8877ecf2364a1cd42e0d69  | 
|--------|

### Summary:
This PR ensures that all watcher processes are terminated when the application is closed by introducing a new `alive` flag in `ManagerState` and checking this flag in the watcher's loop.

**Key points**:
- Add `alive` flag to `ManagerState` to track if the app is closing.
- Modify `start_watcher` in `manager.rs` to terminate watchers if `alive` is false.
- Set `alive` to false in `on_tray_event` in `main.rs` when 'quit' is clicked.
- Minor formatting changes in `build.rs`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!--
ELLIPSIS_HIDDEN
-->
