### PR TITLE
Responsive watchers

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Secondary goal is to add extras supported by Tauri (updater, autostart).
  - [x] Tray icon
      - [x] Basic version (open, exit)
      - [x] Menu for module manager
-     - [ ] Responsive running/stopped state for watchers (no "update" button)
+     - [x] Responsive running/stopped state for watchers (no "update" button)
      - [ ] Start/stop via modules menu
      - [ ] Detect bundled & system modules
  - [ ] Polish

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -317,6 +317,7 @@ version = "0.0.0"
 dependencies = [
  "aw-datastore",
  "aw-server",
+ "lazy_static",
  "nix",
  "serde",
  "serde_json",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -16,6 +16,7 @@ tauri-build = { version = "1.5.1", features = [] }
 tauri = { version = "1.6", features = ["shell-open", "system-tray"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+lazy_static = "1.4"
 #[cfg(unix)]
 nix = { version = "0.28.0", features = ["process", "signal"] }
 #[cfg(windows)]

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -111,7 +111,7 @@ fn create_tray_menu(manager_state: &Arc<Mutex<manager::ManagerState>>) -> System
     let quit = CustomMenuItem::new("quit".to_string(), "Quit");
 
     // modules
-    let mut module_menu = SystemTrayMenu::new().add_item(CustomMenuItem::new("update", "Update"));
+    let mut module_menu = SystemTrayMenu::new();
 
     let state = manager_state.lock().unwrap();
     println!("state: {:?}", state);
@@ -166,13 +166,6 @@ fn on_tray_event(
                 println!("system tray received a open click");
                 let window = app.get_window("main").unwrap();
                 window.show().unwrap();
-            }
-            "update" => {
-                println!("system tray received a update click");
-                // TODO: get rid of this, update when tray opens or something
-                // should update the tray icon menu with the module statuses
-                let tray_handle = app.tray_handle();
-                tray_handle.set_menu(create_tray_menu()).unwrap();
             }
             _ => {}
         },

--- a/src-tauri/src/manager.rs
+++ b/src-tauri/src/manager.rs
@@ -1,3 +1,7 @@
+#[cfg(unix)]
+use nix::sys::signal::{self, Signal};
+#[cfg(unix)]
+use nix::unistd::Pid;
 /// A process manager for ActivityWatch
 ///
 /// Used to start, stop and manage the lifecycle watchers like aw-watcher-afk and aw-watcher-window.
@@ -14,14 +18,10 @@ use std::sync::{
     Arc, Mutex,
 };
 use std::thread;
-#[cfg(unix)]
-use nix::sys::signal::{self, Signal};
-#[cfg(unix)]
-use nix::unistd::Pid;
-#[cfg(windows)]
-use winapi::um::wincon::{CTRL_BREAK_EVENT, GenerateConsoleCtrlEvent};
 #[cfg(windows)]
 use winapi::shared::minwindef::DWORD;
+#[cfg(windows)]
+use winapi::um::wincon::{GenerateConsoleCtrlEvent, CTRL_BREAK_EVENT};
 
 #[derive(Debug)]
 pub enum WatcherMessage {


### PR DESCRIPTION
Makes the system tray responsive. Uses a bit of unsafe blocks but I think it's ok because there can't be any data races for our use case. Could be improved to get rid of the unsafe blocks but I have tried and all solutions either didn't work for me or were too complicated. 

<!--
ELLIPSIS_HIDDEN
-->


----

| :rocket: This description was created by [Ellipsis](https://www.ellipsis.dev) for commit e2e9dd56e9822158ee4a39c732c04af8db5f61d3  | 
|--------|

### Summary:
This PR enhances the system tray's responsiveness by dynamically updating its menu based on the state of background watchers, utilizing global static variables for cross-module synchronization.

**Key points**:
- Added `HANDLE` and `HANDLE_SET` to manage global access to `AppHandle`.
- Implemented `init_app_handle` and `get_app_handle` for setting and retrieving the `AppHandle`.
- Updated `ManagerState` to dynamically update the tray menu when watchers start or stop.
- Used unsafe blocks for global static variable handling, necessary for cross-module updates.
- Ensured thread safety and responsiveness of the system tray through careful state management and synchronization.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!--
ELLIPSIS_HIDDEN
-->
