### PR TITLE
feat: start and stop watchers from the system tray

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Secondary goal is to add extras supported by Tauri (updater, autostart).
      - [x] Basic version (open, exit)
      - [x] Menu for module manager
      - [x] Responsive running/stopped state for watchers (no "update" button)
-     - [ ] Start/stop via modules menu
+     - [x] Start/stop via modules menu
      - [ ] Detect bundled & system modules
  - [ ] Polish
      - [ ] Remove placeholder Vue app

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -18,7 +18,7 @@ static HANDLE: OnceLock<Mutex<AppHandle>> = OnceLock::new();
 lazy_static! {
     static ref HANDLE_CONDVAR: (Mutex<bool>, Condvar) = (Mutex::new(false), Condvar::new());
     static ref WATCHER_CONDVAR: (Mutex<bool>, Condvar) = (Mutex::new(false), Condvar::new());
-    static ref WATCHER_STATE: Mutex<Vec<&'static str>> = Mutex::new(Vec::new());
+    static ref WATCHER_STATE: Mutex<Vec<String>> = Mutex::new(Vec::new());
 }
 
 fn init_app_handle(handle: AppHandle) {
@@ -166,8 +166,7 @@ fn on_tray_event(
             _ => {
                 println!("system tray received a module click at {}", id.as_str());
                 let mut state = manager_state.lock().unwrap();
-                let static_string: &'static str = Box::leak(id.to_owned().into_boxed_str());
-                state.handle_system_click(static_string);
+                state.handle_system_click(id.as_str());
             }
         },
         _ => {}

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -17,8 +17,6 @@ mod manager;
 static HANDLE: OnceLock<Mutex<AppHandle>> = OnceLock::new();
 lazy_static! {
     static ref HANDLE_CONDVAR: (Mutex<bool>, Condvar) = (Mutex::new(false), Condvar::new());
-    static ref WATCHER_CONDVAR: (Mutex<bool>, Condvar) = (Mutex::new(false), Condvar::new());
-    static ref WATCHER_STATE: Mutex<Vec<String>> = Mutex::new(Vec::new());
 }
 
 fn init_app_handle(handle: AppHandle) {
@@ -51,7 +49,7 @@ fn main() {
         .to_string();
 
     let device_id = aw_server::device_id::get_device_id();
-    let (_manager_tx, manager_state) = manager::start_manager();
+    let manager_state = manager::start_manager();
     let tray = create_tray(&manager_state);
     tauri::Builder::default()
         .setup(|app| {

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -164,7 +164,7 @@ fn on_tray_event(
                 window.show().unwrap();
             }
             _ => {
-                println!("system tray received a module click at {}",id.as_str());
+                println!("system tray received a module click at {}", id.as_str());
                 let mut state = manager_state.lock().unwrap();
                 let static_string: &'static str = Box::leak(id.to_owned().into_boxed_str());
                 state.handle_system_click(static_string);

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -154,7 +154,7 @@ fn on_tray_event(
         SystemTrayEvent::MenuItemClick { id, .. } => match id.as_str() {
             "quit" => {
                 println!("system tray received a quit click");
-                let mut state = manager_state.lock().unwrap();
+                let state = manager_state.lock().unwrap();
                 state.stop_watchers();
                 app.exit(0);
             }

--- a/src-tauri/src/manager.rs
+++ b/src-tauri/src/manager.rs
@@ -100,7 +100,7 @@ impl ManagerState {
         let tray_handle = app.tray_handle();
         tray_handle.set_menu(menu).expect("failed to set tray menu");
     }
-    pub fn stop_watcher(&mut self, name: &str) {
+    pub fn stop_watcher(&self, name: &str) {
         if let Some(pid) = self.watchers_pid.get(name) {
             match send_sigterm(*pid) {
                 Ok(_) => {
@@ -112,16 +112,9 @@ impl ManagerState {
             }
         }
     }
-    pub fn stop_watchers(&mut self) {
-        for (name, pid) in self.watchers_pid.iter() {
-            match send_sigterm(*pid) {
-                Ok(_) => {
-                    println!("sent SIGTERM to {name}");
-                }
-                Err(e) => {
-                    println!("failed to send SIGTERM to {name}: {e}");
-                }
-            }
+    pub fn stop_watchers(&self) {
+        for (name, _pid) in self.watchers_pid.iter() {
+            self.stop_watcher(name);
         }
     }
     pub fn handle_system_click(&mut self, name: &str) {

--- a/src-tauri/src/manager.rs
+++ b/src-tauri/src/manager.rs
@@ -75,8 +75,8 @@ impl ManagerState {
                 module,
                 if *running { "Running" } else { "Stopped" }
             );
-            let status = format!("{}", if *running { "Stop"} else {"Start"});
-            let menu = SystemTrayMenu::new().add_item(CustomMenuItem::new(module, status ));
+            let status = format!("{}", if *running { "Stop" } else { "Start" });
+            let menu = SystemTrayMenu::new().add_item(CustomMenuItem::new(module, status));
             let submenu = SystemTraySubmenu::new(label, menu);
             module_menu = module_menu.add_submenu(submenu)
         }
@@ -124,8 +124,8 @@ impl ManagerState {
             }
         }
     }
-    pub fn handle_system_click(&mut self,name: &'static str) {
-        if self.is_watcher_running(name){
+    pub fn handle_system_click(&mut self, name: &'static str) {
+        if self.is_watcher_running(name) {
             self.stop_watcher(name);
         } else {
             let mut state = WATCHER_STATE.lock().unwrap();


### PR DESCRIPTION


<!--
ELLIPSIS_HIDDEN
-->




| :rocket: This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 4d5ef369fe3d15f3fb7c7eaf0b0d467531fb82c8  | 
|--------|

### Summary:
This PR adds functionality to start and stop watchers directly from the system tray, enhancing control and interaction with the application's background watchers.

**Key points**:
- Added system tray functionality to start/stop watchers in `src-tauri/src/main.rs` and `src-tauri/src/manager.rs`.
- Introduced new condition variables `HANDLE_CONDVAR`, `WATCHER_CONDVAR` and state `WATCHER_STATE` for dynamic watcher control.
- Implemented `handle_system_click` in `ManagerState` to toggle watcher states based on system tray interactions.
- Enhanced system tray menu to dynamically display watcher states and control options.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!--
ELLIPSIS_HIDDEN
-->
