### PR TITLE
Detect modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Secondary goal is to add extras supported by Tauri (updater, autostart).
      - [x] Menu for module manager
      - [x] Responsive running/stopped state for watchers (no "update" button)
      - [x] Start/stop via modules menu
-     - [ ] Detect bundled & system modules
+     - [x] Detect bundled & system modules
  - [ ] Polish
      - [ ] Remove placeholder Vue app
          - Or replace with new UI for module management? (a bit redundant)

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -5,9 +5,7 @@ use lazy_static::lazy_static;
 use std::path::PathBuf;
 use std::sync::{Arc, Condvar, Mutex, OnceLock};
 
-use tauri::Manager;
-use tauri::SystemTray;
-use tauri::{AppHandle, SystemTrayEvent};
+use tauri::{AppHandle, Manager, SystemTray, SystemTrayEvent};
 use tauri::{CustomMenuItem, SystemTrayMenu, SystemTrayMenuItem, SystemTraySubmenu};
 
 use aw_server::endpoints::build_rocket;

--- a/src-tauri/src/manager.rs
+++ b/src-tauri/src/manager.rs
@@ -88,6 +88,14 @@ impl ManagerState {
             module_menu = module_menu.add_submenu(submenu)
         }
 
+        for module in self.modules_in_path.iter() {
+            if !self.modules_running.contains_key(module) {
+                let menu = SystemTrayMenu::new().add_item(CustomMenuItem::new(module, "Start"));
+                let submenu = SystemTraySubmenu::new(module, menu);
+                module_menu = module_menu.add_submenu(submenu);
+            }
+        }
+
         let module_submenu = SystemTraySubmenu::new("Modules", module_menu);
         let menu = SystemTrayMenu::new()
             .add_item(open)

--- a/src-tauri/src/manager.rs
+++ b/src-tauri/src/manager.rs
@@ -20,7 +20,6 @@ use std::sync::{
     Arc, Mutex,
 };
 use std::{env, fs, thread};
-// use itertools::Itertools;
 use tauri::{CustomMenuItem, SystemTrayMenu, SystemTrayMenuItem, SystemTraySubmenu};
 #[cfg(windows)]
 use winapi::shared::minwindef::DWORD;

--- a/src-tauri/src/manager.rs
+++ b/src-tauri/src/manager.rs
@@ -4,7 +4,7 @@ use nix::sys::signal::{self, Signal};
 use nix::unistd::Pid;
 /// A process manager for ActivityWatch
 ///
-/// Used to start, stop and manage the lifecycle modules like aw-module-afk and aw-module-window.
+/// Used to start, stop and manage the lifecycle modules like aw-watcher-afk and aw-watcher-window.
 /// A module is a process that runs in the background and sends events to the ActivityWatch server.
 ///
 /// The manager is responsible for starting and stopping the modules, and for keeping track of
@@ -163,7 +163,7 @@ pub fn start_manager() -> Arc<Mutex<ManagerState>> {
     let state = Arc::new(Mutex::new(ManagerState::new(tx)));
 
     // Start the modules
-    let autostart_modules = ["aw-module-afk", "aw-module-window"];
+    let autostart_modules = ["aw-watcher-afk", "aw-watcher-window"];
     for module in autostart_modules.iter() {
         state.lock().unwrap().start_module(module);
     }


### PR DESCRIPTION
Fixes https://github.com/ActivityWatch/aw-tauri/issues/12

---


<!--
ELLIPSIS_HIDDEN
-->
| :rocket: This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 28a093e63aa488118cb26526bf96c794d391e573  | 
|--------|

### Summary:
This PR enhances module detection by adding functionality to identify and manage 'aw' prefixed executables in the system PATH, and consolidates `tauri` imports for cleaner code.

**Key points**:
- Consolidated `tauri` imports in `src-tauri/src/main.rs`.
- Added `get_modules_in_path` function in `src-tauri/src/manager.rs` to detect 'aw' prefixed executables in PATH.
- Populated `modules_in_path` in `ManagerState` to track and manage executable modules found in system PATH.
- Updated system tray menu creation to include options for starting modules found in PATH but not currently running.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)

<!--
ELLIPSIS_HIDDEN
-->
