### PR TITLE
fix: create config dir if doesn't exist

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -80,6 +80,8 @@ pub(crate) fn get_config() -> &'static Config {
         } else {
             let config = Config::default();
             let config_str = toml::to_string(&config).expect("Failed to serialize config");
+            std::fs::create_dir_all(config_path.parent().unwrap())
+                .expect("Failed to create config dir");
             std::fs::write(config_path, config_str).expect("Failed to write config file");
             config
         }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add directory creation in `get_config()` to ensure config directory exists before writing the config file.
> 
>   - **Behavior**:
>     - In `get_config()` in `lib.rs`, add `std::fs::create_dir_all()` to create the config directory if it doesn't exist before writing the config file.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ActivityWatch%2Faw-tauri&utm_source=github&utm_medium=referral)<sup> for 7c872095c78c9ef76398e88b7b896b58849fa27a. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->