### PR TITLE
Add devbox+direnv+nix auto-build tool setup

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+# Automatically sets up your devbox environment whenever you cd into this
+# directory via our direnv integration:
+
+eval "$(devbox generate direnv --print-envrc)"
+
+# check out https://www.jetpack.io/devbox/docs/ide_configuration/direnv/
+# for more details

--- a/README.md
+++ b/README.md
@@ -33,13 +33,15 @@ Benefits of Tauri:
  - Tauri CLI (`npm install -g @tauri-apps/cli`)
  - Tauri dependencies (see [their docs](https://v2.tauri.app/start/prerequisites/))
 
+Alternatively, you can quickly get a development environment up and running on MacOS or Linux by running `devbox shell` in the project directory (to install devbox: `curl -fsSL https://get.jetify.com/devbox | bash`)
+
 # Usage
 
 To run:
 
 ```sh
 npm install
-npm run tauri dev
+make dev
 ```
 
 # Repo stucture

--- a/devbox.json
+++ b/devbox.json
@@ -1,0 +1,53 @@
+{
+  "$schema": "https://raw.githubusercontent.com/jetify-com/devbox/0.13.6/.schema/devbox.schema.json",
+  "packages": {
+    "nodejs": "20.18.1",
+    "cargo":  "latest",
+    "rustc":  "latest",
+    "libiconv": {
+       "version": "latest",
+       "platforms": ["aarch64-darwin", "x86_64-darwin"],
+    },
+    "darwin.apple_sdk.frameworks.Cocoa": {
+      "version":   "",
+      "platforms": ["aarch64-darwin", "x86_64-darwin"],
+    },
+    "darwin.apple_sdk.frameworks.WebKit": {
+      "version":   "",
+      "platforms": ["aarch64-darwin", "x86_64-darwin"],
+    },
+    "pkg-config": {
+      "version":            "latest",
+      "excluded_platforms": ["aarch64-darwin", "x86_64-darwin"],
+    },
+    // Helpful map for pkg-config -> nix packages: https://github.com/input-output-hk/haskell.nix/blob/master/lib/pkgconf-nixpkgs-map.nix
+    "openssl.dev": {
+      "excluded_platforms": ["aarch64-darwin", "x86_64-darwin"],
+    },
+    "gtk4.dev": {
+      "excluded_platforms": ["aarch64-darwin", "x86_64-darwin"],
+    },
+    "libsoup_3.dev": {
+      "excluded_platforms": ["aarch64-darwin", "x86_64-darwin"],
+    },
+    "webkitgtk_4_1.dev": {
+      "excluded_platforms": ["aarch64-darwin", "x86_64-darwin"],
+    },
+  },
+  "shell": {
+    "init_hook": [
+      "[ ! -d node_modules ] && echo Running npm install && npm install",
+      "export COLOR_BLACK='\\e[0;30m' COLOR_GRAY='\\e[1;30m' COLOR_RED='\\e[0;31m' COLOR_LIGHT_RED='\\e[1;31m' COLOR_GREEN='\\e[0;32m' COLOR_LIGHT_GREEN='\\e[1;32m' COLOR_BROWN='\\e[0;33m' COLOR_YELLOW='\\e[1;33m' COLOR_BLUE='\\e[0;34m' COLOR_LIGHT_BLUE='\\e[1;34m' COLOR_PURPLE='\\e[0;35m' COLOR_LIGHT_PURPLE='\\e[1;35m' COLOR_CYAN='\\e[0;36m'; export COLOR_LIGHT_CYAN='\\e[1;36m'; export COLOR_LIGHT_GRAY='\\e[0;37m'; export COLOR_WHITE='\\e[1;37m'",
+      "echo -e ${COLOR_RED}-------------------------------------------------------------------------------${COLOR_LIGHT_GRAY}",
+      "echo -e \"${COLOR_PURPLE}ActivityWatch Tauri${COLOR_LIGHT_GRAY}\"",
+      "echo -e \"Build: ${COLOR_LIGHT_GREEN}make${COLOR_LIGHT_GRAY}\"",
+      "echo -e \"Development run: ${COLOR_LIGHT_GREEN}make dev${COLOR_LIGHT_GRAY}\"",
+      "echo -e ${COLOR_RED}-------------------------------------------------------------------------------${COLOR_LIGHT_GRAY}",
+    ],
+    "scripts": {
+      "test": [
+        "echo \"Error: no test specified\" && exit 1",
+      ],
+    },
+  },
+}


### PR DESCRIPTION
You can use devbox (install `curl -fsSL https://get.jetify.com/devbox | bash`) to download all the require build tooling and library dependencies for your project, by checking out the project, cd-ing into the project and then running `devbox shell` (if you have direnv installed, this will happen automatically).

This is a draft PR as currently the build process is not 100% successful, so there maybe a step or two missing.

I'm stumped, so any guidance you can provide would be very helpful. 

Here are the errors:

## 1. Building the aw-webui sub-module fails with this error:
```
 ERROR  Failed to compile with 1 error                                                                                                                   20:50:50

 error  in ./src/stores/activity.ts + 3 modules

Unexpected end of JSON input

 ERROR  Error: Build failed with errors.
Error: Build failed with errors.
    at /home/deftdawg/source/aw-tauri/aw-webui/node_modules/@vue/cli-service/lib/commands/build/index.js:207:23
    at /home/deftdawg/source/aw-tauri/aw-webui/node_modules/webpack/lib/webpack.js:157:8
    at /home/deftdawg/source/aw-tauri/aw-webui/node_modules/webpack/lib/HookWebpackError.js:68:3
    at Hook.eval [as callAsync] (eval at create (/home/deftdawg/source/aw-tauri/aw-webui/node_modules/webpack/node_modules/tapable/lib/HookCodeFactory.js:33:10), <anonymous>:6:1)
    at Hook.CALL_ASYNC_DELEGATE [as _callAsync] (/home/deftdawg/source/aw-tauri/aw-webui/node_modules/webpack/node_modules/tapable/lib/Hook.js:18:14)
    at Cache.shutdown (/home/deftdawg/source/aw-tauri/aw-webui/node_modules/webpack/lib/Cache.js:150:23)
    at /home/deftdawg/source/aw-tauri/aw-webui/node_modules/webpack/lib/Compiler.js:1229:15
    at Hook.eval [as callAsync] (eval at create (/home/deftdawg/source/aw-tauri/aw-webui/node_modules/webpack/node_modules/tapable/lib/HookCodeFactory.js:33:10), <anonymous>:6:1)
    at Hook.CALL_ASYNC_DELEGATE [as _callAsync] (/home/deftdawg/source/aw-tauri/aw-webui/node_modules/webpack/node_modules/tapable/lib/Hook.js:18:14)
    at Compiler.close (/home/deftdawg/source/aw-tauri/aw-webui/node_modules/webpack/lib/Compiler.js:1222:23)
    at /home/deftdawg/source/aw-tauri/aw-webui/node_modules/webpack/lib/webpack.js:156:16
    at finalCallback (/home/deftdawg/source/aw-tauri/aw-webui/node_modules/webpack/lib/Compiler.js:441:32)
    at /home/deftdawg/source/aw-tauri/aw-webui/node_modules/webpack/lib/Compiler.js:458:13
    at Hook.eval [as callAsync] (eval at create (/home/deftdawg/source/aw-tauri/aw-webui/node_modules/webpack/node_modules/tapable/lib/HookCodeFactory.js:33:10), <anonymous>:33:1)
    at Hook.CALL_ASYNC_DELEGATE [as _callAsync] (/home/deftdawg/source/aw-tauri/aw-webui/node_modules/webpack/node_modules/tapable/lib/Hook.js:18:14)
    at onCompiled (/home/deftdawg/source/aw-tauri/aw-webui/node_modules/webpack/lib/Compiler.js:456:21)
    at /home/deftdawg/source/aw-tauri/aw-webui/node_modules/webpack/lib/Compiler.js:1200:17
    at eval (eval at create (/home/deftdawg/source/aw-tauri/aw-webui/node_modules/webpack/node_modules/tapable/lib/HookCodeFactory.js:33:10), <anonymous>:14:1)
    at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
```

## 2. aw-tauri's `npm run tauri dev` fails with this:
```
   Compiling tauri-plugin-single-instance v2.2.0
error: proc macro panicked
   --> src/lib.rs:336:14
    |
336 |         .run(tauri::generate_context!())
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: message: failed to open icon /home/deftdawg/source/aw-tauri/src-tauri/icons/32x32.png: No such file or directory (os error 2)
```


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add devbox, direnv, and nix setup for automated build tool configuration, with unresolved build issues.
> 
>   - **Setup**:
>     - Adds `devbox.json` to specify build tools and dependencies using devbox.
>     - Introduces `.envrc` for direnv integration to automatically set up the devbox environment.
>     - Updates `README.md` to include instructions for setting up the development environment using devbox.
>   - **Build Issues**:
>     - `aw-webui` sub-module fails with JSON parsing error during build.
>     - `aw-tauri` fails to run due to missing icon file `32x32.png`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ActivityWatch%2Faw-tauri&utm_source=github&utm_medium=referral)<sup> for cac1cebae672cd36f9a1afe70fbb8389cd0fb92b. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->