### PR TITLE
feat: use checkmarks for module running state

### DIFF
--- a/src-tauri/src/manager.rs
+++ b/src-tauri/src/manager.rs
@@ -24,7 +24,7 @@ use std::time::Duration;
 use tauri_plugin_dialog::{DialogExt, MessageDialogKind};
 
 use std::{env, fs, thread};
-use tauri::menu::{Menu, MenuItem, SubmenuBuilder};
+use tauri::menu::{CheckMenuItem, Menu, MenuItem, SubmenuBuilder};
 
 // use tauri::{CustomMenuItem, SystemTrayMenu, SystemTrayMenuItem, SystemTraySubmenu};
 #[cfg(windows)]
@@ -80,8 +80,6 @@ impl ManagerState {
         self.update_tray_menu();
     }
     fn update_tray_menu(&mut self) {
-        // let open = CustomMenuItem::new("open".to_string(), "Open");
-        // let quit = CustomMenuItem::new("quit".to_string(), "Quit");
         let (lock, cvar) = &*HANDLE_CONDVAR;
         let mut state = lock.lock().unwrap();
 
@@ -101,13 +99,10 @@ impl ManagerState {
 
         let mut modules_submenu_builder = SubmenuBuilder::new(app, "Modules");
         for (module, running) in self.modules_running.iter() {
-            let label = format!(
-                "{} ({})",
-                module,
-                if *running { "Running" } else { "Stopped" }
-            );
-            let module_menu = MenuItem::with_id(app, module, &label, true, None::<&str>)
-                .expect("failed to create module menu item");
+            let label = module;
+            let module_menu =
+                CheckMenuItem::with_id(app, module, &label, true, *running, None::<&str>)
+                    .expect("failed to create module menu item");
             modules_submenu_builder = modules_submenu_builder.item(&module_menu);
         }
 

--- a/src-tauri/src/manager.rs
+++ b/src-tauri/src/manager.rs
@@ -315,6 +315,8 @@ fn get_modules_in_path() -> BTreeSet<String> {
     }
     set.remove("awk"); // common in most unix systems
     set.remove("aw-tauri");
+    set.remove("aw-client");
+    set.remove("aw-cli");
 
     set
 }
@@ -335,6 +337,9 @@ fn get_modules_in_path() -> BTreeSet<String> {
             }
         }
     }
+    set.remove("aw-tauri");
+    set.remove("aw-client");
+    set.remove("aw-cli");
 
     set
 }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Use `CheckMenuItem` for module running state in tray menu and remove certain modules from path in `manager.rs`.
> 
>   - **Behavior**:
>     - Use `CheckMenuItem` instead of `MenuItem` in `update_tray_menu()` in `manager.rs` to show module running state with checkmarks.
>   - **Modules**:
>     - Remove `aw-client` and `aw-cli` from `get_modules_in_path()` in `manager.rs` for both Unix and Windows.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ActivityWatch%2Faw-tauri&utm_source=github&utm_medium=referral)<sup> for a05eac2e07cb44c63e76829d8423958276263de9. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->