### PR TITLE
CI: update the release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform: [macos-latest, ubuntu-20.04, windows-latest]
+        platform: [macos-latest, ubuntu-22.04, windows-latest]
     runs-on: ${{ matrix.platform }}
 
     steps:
@@ -22,11 +22,11 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install dependencies (ubuntu only)
-        if: matrix.platform == 'ubuntu-20.04'
+        if: matrix.platform == 'ubuntu-22.04'
         # You can remove libayatana-appindicator3-dev if you don't use the system tray feature.
         run: |
           sudo apt-get update
-          sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.0-dev libayatana-appindicator3-dev librsvg2-dev
+           sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
 
       - name: Rust setup
         uses: dtolnay/rust-toolchain@stable
@@ -55,7 +55,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tagName: ${{ github.ref_name }} # This only works if your workflow triggers on new tags.
-          releaseName: 'App Name v__VERSION__' # tauri-action replaces \_\_VERSION\_\_ with the app version.
+          releaseName: 'aw-tauri v__VERSION__' # tauri-action replaces \_\_VERSION\_\_ with the app version.
           releaseBody: 'See the assets to download and install this version.'
           releaseDraft: true
           prerelease: false

--- a/src-tauri/src/manager.rs
+++ b/src-tauri/src/manager.rs
@@ -183,7 +183,6 @@ fn send_sigterm(pid: u32) -> Result<(), std::io::Error> {
     } else {
         return Ok(());
     }
-    Ok(())
 }
 pub fn start_manager() -> Arc<Mutex<ManagerState>> {
     let (tx, rx) = channel();


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update CI release workflow to use Ubuntu 22.04 and clean up redundant code in manager.rs.
> 
>   - **CI Workflow**:
>     - Update Ubuntu version from `ubuntu-20.04` to `ubuntu-22.04` in `.github/workflows/release.yml`.
>     - Modify dependencies for Ubuntu: replace `libwebkit2gtk-4.0-dev` with `libwebkit2gtk-4.1-dev`, `libayatana-appindicator3-dev` with `libappindicator3-dev`, and add `patchelf`.
>     - Change release name format to 'aw-tauri v__VERSION__'.
>   - **Code Cleanup**:
>     - Remove redundant `Ok(())` statement in `send_sigterm()` in `manager.rs`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ActivityWatch%2Faw-tauri&utm_source=github&utm_medium=referral)<sup> for 69fa27211ef81d5b115e88253e1199408b923886. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->