### PR TITLE
feat: play nice with aw-qt

### DIFF
--- a/src-tauri/src/manager.rs
+++ b/src-tauri/src/manager.rs
@@ -252,7 +252,7 @@ fn handle(rx: Receiver<ModuleMessage>, state: Arc<Mutex<ManagerState>>) {
                             app.dialog()
                                 .message(format!("{name_clone} crashed. Restarting..."))
                                 .kind(MessageDialogKind::Error)
-                                .title("Warning")
+                                .title("Aw-Tauri")
                                 .show(|_| {});
                             error!("Module {name_clone} crashed and is being restarted");
                         } else {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds port availability check in `lib.rs` to prevent server launch on occupied ports.
> 
>   - **Behavior**:
>     - Adds `is_port_available()` function to check if a port is free in `lib.rs`.
>     - In `run()`, checks port availability before launching the server and panics if the port is in use.
>   - **Functions**:
>     - New function `is_port_available()` added to `lib.rs` to determine port status using `TcpListener`.
>   - **Misc**:
>     - Imports `SocketAddr` and `TcpListener` in `lib.rs` for port checking functionality.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ActivityWatch%2Faw-tauri&utm_source=github&utm_medium=referral)<sup> for 04bfe39c66ea45f570b0d4a20ea2901a885d119d. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->