### PR TITLE
fix:start modules via full path

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -263,8 +263,7 @@ impl Default for UserConfig {
 fn get_config_path() -> PathBuf {
     let project_dirs =
         ProjectDirs::from("net", "ActivityWatch", "Aw-Tauri").expect("Failed to get project dirs");
-    let config_path = project_dirs.config_dir().join("config.toml");
-    config_path
+    project_dirs.config_dir().join("config.toml")
 }
 #[cfg(target_os = "linux")]
 fn get_config_path() -> PathBuf {

--- a/src-tauri/src/manager.rs
+++ b/src-tauri/src/manager.rs
@@ -252,7 +252,7 @@ fn handle(rx: Receiver<ModuleMessage>, state: Arc<Mutex<ManagerState>>) {
                             app.dialog()
                                 .message(format!("{name_clone} crashed. Restarting..."))
                                 .kind(MessageDialogKind::Error)
-                                .title("Warning")
+                                .title("Aw-Tauri")
                                 .show(|_| {});
                             error!("Module {name_clone} crashed and is being restarted");
                         } else {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Enhance module management by executing modules via full paths and add port availability check before server start.
> 
>   - **Behavior**:
>     - Adds `is_port_available()` in `lib.rs` to check port availability before starting the server.
>     - Displays error dialog if the port is in use and prevents server start.
>   - **Module Management**:
>     - Changes `modules_in_path` from `BTreeSet<String>` to `BTreeMap<String, PathBuf>` in `manager.rs` to store full paths.
>     - Updates `start_module_thread()` to use full path for module execution.
>     - Modifies `get_modules_in_path()` to return full paths for modules.
>   - **Misc**:
>     - Minor refactoring in `get_config_path()` in `lib.rs` for cleaner code.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ActivityWatch%2Faw-tauri&utm_source=github&utm_medium=referral)<sup> for e2c2605ae907d093f8bce37c84a0e984bfe350f2. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->