### PR TITLE
feat: hide icon from dock on macos

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -328,6 +328,8 @@ pub fn run() {
             info!("Another instance is running, quitting!");
         }))
         .setup(|app| {
+            #[cfg(target_os = "macos")]
+            app.set_activation_policy(tauri::ActivationPolicy::Accessory);
             {
                 init_app_handle(app.handle().clone());
                 let user_config = get_config();


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Set activation policy to `Accessory` on macOS to hide app icon from dock in `run()` function.
> 
>   - **Behavior**:
>     - On macOS, set activation policy to `Accessory` in `run()` function to hide app icon from dock.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ActivityWatch%2Faw-tauri&utm_source=github&utm_medium=referral)<sup> for acb2de288016f3626986ef2be2d1a180fe993588. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->