### PR TITLE
feat: show window on first run

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -445,7 +445,10 @@ pub fn run() {
                         state.handle_system_click(&event.id().0);
                     }
                 });
-                if user_config.defaults.autostart && user_config.defaults.autostart_minimized {
+                if user_config.defaults.autostart
+                    && user_config.defaults.autostart_minimized
+                    && !*is_first_run()
+                {
                     if let Some(window) = app.webview_windows().get("main") {
                         window.hide().unwrap();
                     }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Modify `run()` in `lib.rs` to show the main window on the first run, even if autostart is minimized.
> 
>   - **Behavior**:
>     - Modify `run()` in `lib.rs` to show the main window on the first run, even if `autostart` and `autostart_minimized` are enabled.
>     - Uses `is_first_run()` to determine if it's the first run.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ActivityWatch%2Faw-tauri&utm_source=github&utm_medium=referral)<sup> for eef8300f76b4a3b181ee74719edcf54936498bf2. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->