### PR TITLE
feat: update the discovery_path for macos + misc refactors

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -209,13 +209,15 @@ pub struct Defaults {
 
 impl Default for Defaults {
     fn default() -> Self {
-        let discovery_path = if cfg!(unix) {
+        let discovery_path = if cfg!(target_os = "linux") {
             UserDirs::new()
                 .map(|dirs| dirs.home_dir().join("aw-modules"))
                 .unwrap_or_default()
         } else if cfg!(windows) {
             let username = std::env::var("USERNAME").unwrap_or_default();
             PathBuf::from(format!(r"C:\Users\{}\aw-modules", username))
+        } else if cfg!(target_os = "macos") {
+            PathBuf::from("/Applications/ActivityWatch.app/Contents/MacOS")
         } else {
             PathBuf::new()
         };

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -331,6 +331,7 @@ pub fn run() {
             #[cfg(target_os = "macos")]
             app.set_activation_policy(tauri::ActivationPolicy::Accessory);
             {
+                //TODO: Some of this setup could run concurrently. Could slash a few 100ms in startup?
                 init_app_handle(app.handle().clone());
                 let user_config = get_config();
                 // Get the autostart manager
@@ -338,24 +339,24 @@ pub fn run() {
 
                 match user_config.defaults.autostart {
                     true => {
-                        autostart_manager
-                            .enable()
-                            .expect("Unable to enable autostart");
+                        if !autostart_manager
+                            .is_enabled()
+                            .expect("failed to get autostart state")
+                        {
+                            autostart_manager
+                                .enable()
+                                .expect("Unable to enable autostart");
+                            info!("Registered for autostart: true");
+                        }
                     }
                     false => {
+                        //checks for state before disabling no need to check twice
                         autostart_manager
                             .disable()
                             .expect("Unable to disable autosart");
+                        info!("Registered for autostart: false");
                     }
                 }
-
-                // Check enable state
-                info!(
-                    "Registered for autostart: {}",
-                    autostart_manager
-                        .is_enabled()
-                        .expect("failed to get autostart state")
-                );
 
                 let testing = true;
                 let legacy_import = false;

--- a/src-tauri/src/manager.rs
+++ b/src-tauri/src/manager.rs
@@ -7,15 +7,21 @@
 /// their state.
 ///
 /// If a module crashes, the manager will notify the user and ask if they want to restart it.
-use log::{debug, error, info};
 
 #[cfg(unix)]
-use nix::sys::signal::{self, Signal};
-#[cfg(unix)]
-use nix::unistd::Pid;
+use {
+    nix::sys::signal::{self, Signal},
+    nix::unistd::Pid,
+    std::os::unix::fs::PermissionsExt,
+};
+#[cfg(windows)]
+use {
+    winapi::shared::minwindef::DWORD,
+    winapi::um::wincon::{GenerateConsoleCtrlEvent, CTRL_BREAK_EVENT},
+};
+
+use log::{debug, error, info};
 use std::collections::{BTreeMap, HashMap};
-#[cfg(unix)]
-use std::os::unix::fs::PermissionsExt;
 use std::path::PathBuf;
 use std::process::Command;
 use std::sync::{
@@ -26,11 +32,6 @@ use std::time::Duration;
 use std::{env, fs, thread};
 use tauri::menu::{CheckMenuItem, Menu, MenuItem, SubmenuBuilder};
 use tauri_plugin_dialog::{DialogExt, MessageDialogKind};
-
-#[cfg(windows)]
-use winapi::shared::minwindef::DWORD;
-#[cfg(windows)]
-use winapi::um::wincon::{GenerateConsoleCtrlEvent, CTRL_BREAK_EVENT};
 
 use crate::{get_app_handle, get_config, get_tray_id, HANDLE_CONDVAR};
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update macOS discovery path and refactor module management in `lib.rs` and `manager.rs`.
> 
>   - **Behavior**:
>     - Update `discovery_path` for macOS in `Defaults::default()` in `lib.rs` to `/Applications/ActivityWatch.app/Contents/MacOS`.
>     - Optimize autostart logic in `run()` in `lib.rs` by checking state before enabling/disabling.
>   - **Refactors**:
>     - Rename `get_modules_in_path()` to `discover_modules()` in `manager.rs` and `lib.rs`.
>     - Rename `modules_in_path` to `modules_discovered` in `ManagerState` in `manager.rs`.
>     - Reorganize imports in `manager.rs` for clarity.
>   - **Misc**:
>     - Add TODO comment in `run()` in `lib.rs` suggesting concurrent setup to improve startup time.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ActivityWatch%2Faw-tauri&utm_source=github&utm_medium=referral)<sup> for 4e992dac3a5ef11614035c2ac99fc7be3e26bd4a. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->