### PR TITLE
chore: update aw-webui to the latest version

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -458,7 +458,7 @@ pub fn run() {
                             .reveal_item_in_dir(config_dir)
                             .expect("Failed to open config folder");
                     } else if event.id().0 == "log_folder" {
-                        let log_path = logging::get_log_filepath();
+                        let log_path = logging::get_log_path();
                         let log_dir = log_path.parent().unwrap_or(&log_path);
                         app.opener()
                             .reveal_item_in_dir(log_dir)

--- a/src-tauri/src/logging.rs
+++ b/src-tauri/src/logging.rs
@@ -4,7 +4,7 @@ use log::LevelFilter;
 use std::path::PathBuf;
 
 pub fn setup_logging() -> Result<(), fern::InitError> {
-    let log_path = get_log_filepath();
+    let log_path = get_log_path();
     std::fs::create_dir_all(&log_path)?;
     let log_file = log_path.join("aw-tauri.log");
 
@@ -49,7 +49,7 @@ pub fn setup_logging() -> Result<(), fern::InitError> {
     Ok(())
 }
 
-pub fn get_log_filepath() -> PathBuf {
+pub fn get_log_path() -> PathBuf {
     // TODO: creates an aw-tauri folder in linux, move inside the legacy activitywatch folder
     let project_dirs =
         ProjectDirs::from("net", "ActivityWatch", "Aw-Tauri").expect("Failed to get project dirs");

--- a/src-tauri/src/manager.rs
+++ b/src-tauri/src/manager.rs
@@ -98,9 +98,9 @@ impl ManagerState {
         let app = &*get_app_handle().lock().expect("failed to get app handle");
         debug!("App handle acquired");
 
-        let open = MenuItem::with_id(app, "open", "Open", true, None::<&str>)
+        let open = MenuItem::with_id(app, "open", "Open Dashboard", true, None::<&str>)
             .expect("failed to create open menu item");
-        let quit = MenuItem::with_id(app, "quit", "Quit", true, None::<&str>)
+        let quit = MenuItem::with_id(app, "quit", "Quit ActivityWatch", true, None::<&str>)
             .expect("failed to create quit menu item");
 
         let mut modules_submenu_builder = SubmenuBuilder::new(app, "Modules");

--- a/src-tauri/src/manager.rs
+++ b/src-tauri/src/manager.rs
@@ -1,12 +1,12 @@
-/// A process manager for ActivityWatch
-///
-/// Used to start, stop and manage the lifecycle modules like aw-watcher-afk and aw-watcher-window.
-/// A module is a process that runs in the background and sends events to the ActivityWatch server.
-///
-/// The manager is responsible for starting and stopping the modules, and for keeping track of
-/// their state.
-///
-/// If a module crashes, the manager will notify the user and ask if they want to restart it.
+//! A process manager for ActivityWatch
+//!
+//! Used to start, stop and manage the lifecycle modules like aw-watcher-afk and aw-watcher-window.
+//! A module is a process that runs in the background and sends events to the ActivityWatch server.
+//!
+//! The manager is responsible for starting and stopping the modules, and for keeping track of
+//! their state.
+//!
+//! If a module crashes, the manager will notify the user and ask if they want to restart it.
 
 #[cfg(unix)]
 use {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update `aw-webui` submodule and rename `get_log_filepath()` to `get_log_path()` in `logging.rs`.
> 
>   - **Submodule Update**:
>     - Update `aw-webui` submodule to commit `053b8d62a868094d4c86dbaf4a2b8624324b5706`.
>   - **Function Renames**:
>     - Rename `get_log_filepath()` to `get_log_path()` in `logging.rs` and update references in `lib.rs`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ActivityWatch%2Faw-tauri&utm_source=github&utm_medium=referral)<sup> for 524112eb1f277608f24288ec42df8cbc580c3d56. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->