### PR TITLE
ci: arm builds for linux

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform: [macos-latest, ubuntu-22.04, windows-latest]
+        include:
+          - platform: 'macos-latest'
+          - platform: 'ubuntu-22.04'
+          - platform: 'ubuntu-22.04-arm' # for Arm based linux.
+          - platform: 'windows-latest'
     runs-on: ${{ matrix.platform }}
 
     steps:
@@ -27,6 +31,13 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.1-dev libayatana-appindicator3-dev librsvg2-dev \
             libjavascriptcoregtk-4.1-dev libsoup-3.0-dev
+      
+      - name: Install dependencies (ubuntu-arm only)
+        if: matrix.platform == 'ubuntu-22.04-arm'
+        # You can remove libayatana-appindicator3-dev if you don't use the system tray feature.
+        run: |
+          sudo apt-get update
+           sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf libgtk-3-dev xdg-utils
 
       - name: Rust setup
         uses: dtolnay/rust-toolchain@stable
@@ -52,3 +63,5 @@ jobs:
         uses: tauri-apps/tauri-action@v0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          args: ${{ matrix.args }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform: [macos-latest, ubuntu-22.04, windows-latest]
+        include:
+          - platform: 'macos-latest'
+          - platform: 'ubuntu-22.04'
+          - platform: 'ubuntu-22.04-arm' # for Arm based linux.
+          - platform: 'windows-latest'
     runs-on: ${{ matrix.platform }}
 
     steps:
@@ -27,6 +31,13 @@ jobs:
         run: |
           sudo apt-get update
            sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
+      
+      - name: Install dependencies (ubuntu-arm only)
+        if: matrix.platform == 'ubuntu-22.04-arm'
+        # You can remove libayatana-appindicator3-dev if you don't use the system tray feature.
+        run: |
+          sudo apt-get update
+           sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf libgtk-3-dev xdg-utils
 
       - name: Rust setup
         uses: dtolnay/rust-toolchain@stable
@@ -59,3 +70,4 @@ jobs:
           releaseBody: 'See the assets to download and install this version.'
           releaseDraft: true
           prerelease: false
+          args: ${{ matrix.args }}


### PR DESCRIPTION
#73 
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add ARM build support for macOS and Linux in GitHub Actions workflows.
> 
>   - **Build and Release Workflows**:
>     - Add ARM build support for macOS and Linux in `build.yml` and `release.yml`.
>     - Modify matrix strategy to include `macos-latest` with `--target aarch64-apple-darwin` and `ubuntu-22.04-arm`.
>     - Add `args` parameter to `tauri-action` step to pass target architecture.
>   - **Dependencies**:
>     - Add ARM-specific dependencies for `ubuntu-22.04-arm` in both workflows.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ActivityWatch%2Faw-tauri&utm_source=github&utm_medium=referral)<sup> for 597f06a94f1343d9109eb1eda576a108db8651ec. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->