### PR TITLE
fix:additional console windows on Windows

### DIFF
--- a/src-tauri/src/manager.rs
+++ b/src-tauri/src/manager.rs
@@ -16,7 +16,9 @@ use {
 };
 #[cfg(windows)]
 use {
+    std::os::windows::process::CommandExt,
     winapi::shared::minwindef::DWORD,
+    winapi::um::winbase::CREATE_NO_WINDOW,
     winapi::um::wincon::{GenerateConsoleCtrlEvent, CTRL_BREAK_EVENT},
 };
 
@@ -328,6 +330,10 @@ fn start_module_thread(
         } else {
             command.args(["--port", port_string.as_str()]);
         }
+
+        // Set creation flags on Windows to hide console window
+        #[cfg(windows)]
+        command.creation_flags(CREATE_NO_WINDOW);
 
         let child = command.stdout(std::process::Stdio::piped()).spawn();
 


### PR DESCRIPTION
Fixes #77 
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes issue #77 by setting `CREATE_NO_WINDOW` flag in `start_module_thread()` to prevent additional console windows on Windows.
> 
>   - **Behavior**:
>     - On Windows, set `CREATE_NO_WINDOW` flag in `start_module_thread()` in `manager.rs` to prevent additional console windows when starting modules.
>   - **Misc**:
>     - Fixes issue #77 related to additional console windows on Windows.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ActivityWatch%2Faw-tauri&utm_source=github&utm_medium=referral)<sup> for bcf98983e8465dcf28f0a4ab2c13ae7bb9dc454d. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->