### PR TITLE
feat: add menu separators + exclude aw-server from modules menu

### DIFF
--- a/src-tauri/src/manager.rs
+++ b/src-tauri/src/manager.rs
@@ -32,7 +32,7 @@ use std::sync::{
 };
 use std::time::Duration;
 use std::{env, fs, thread};
-use tauri::menu::{CheckMenuItem, Menu, MenuItem, SubmenuBuilder};
+use tauri::menu::{CheckMenuItem, Menu, MenuItem, PredefinedMenuItem, SubmenuBuilder};
 use tauri_plugin_dialog::{DialogExt, MessageDialogKind};
 
 use crate::{get_app_handle, get_config, get_tray_id, HANDLE_CONDVAR};
@@ -138,10 +138,19 @@ impl ManagerState {
         let log_folder =
             MenuItem::with_id(app, "log_folder", "Open log folder", true, None::<&str>)
                 .expect("failed to create log folder menu item");
-
+        let separator = PredefinedMenuItem::separator(app).expect("failed to create separator");
         let menu = Menu::with_items(
             app,
-            &[&open, &module_submenu, &config_folder, &log_folder, &quit],
+            &[
+                &open,
+                &separator,
+                &module_submenu,
+                &separator,
+                &config_folder,
+                &log_folder,
+                &separator,
+                &quit,
+            ],
         )
         .expect("failed to create tray menu");
 

--- a/src-tauri/src/manager.rs
+++ b/src-tauri/src/manager.rs
@@ -376,7 +376,15 @@ fn start_module_thread(
 
 #[cfg(unix)]
 fn discover_modules() -> BTreeMap<String, PathBuf> {
-    let excluded = ["awk", "aw-tauri", "aw-client", "aw-cli", "aw-qt"];
+    let excluded = [
+        "awk",
+        "aw-tauri",
+        "aw-client",
+        "aw-cli",
+        "aw-qt",
+        "aw-server",
+        "aw-server-rust",
+    ];
     let config = crate::get_config();
 
     let path = env::var_os("PATH").unwrap_or_default();
@@ -415,7 +423,15 @@ fn discover_modules() -> BTreeMap<String, PathBuf> {
 
 #[cfg(windows)]
 fn discover_modules() -> BTreeMap<String, PathBuf> {
-    let excluded = ["awk", "aw-tauri", "aw-client", "aw-cli", "aw-qt"];
+    let excluded = [
+        "awk",
+        "aw-tauri",
+        "aw-client",
+        "aw-cli",
+        "aw-qt",
+        "aw-server",
+        "aw-server-rust",
+    ];
     let config = crate::get_config();
 
     let path = env::var_os("PATH").unwrap_or_default();


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add menu separators in `manager.rs` to visually group tray menu items using `PredefinedMenuItem::separator`.
> 
>   - **UI Enhancement**:
>     - Add menu separators using `PredefinedMenuItem::separator` in `manager.rs` to visually group menu items in the tray menu.
>     - Separators added between `open`, `module_submenu`, `config_folder`, `log_folder`, and `quit` items.
>   - **Code Changes**:
>     - Import `PredefinedMenuItem` in `manager.rs`.
>     - Modify `update_tray_menu()` in `ManagerState` to include separators in the menu.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ActivityWatch%2Faw-tauri&utm_source=github&utm_medium=referral)<sup> for 159bb8300dbb8b4abf9118706cb02a59da32c605. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->