### PR TITLE
feat: multiple discovery paths

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ src-tauri/icons/icon.png: aw-webui/.git
 	npm run tauri icon "./aw-webui/media/logo/logo.png"
 
 aw-webui/dist: aw-webui/.git
-	cd aw-webui && make
+	cd aw-webui && make build
 
 prebuild: aw-webui/dist src-tauri/icons/icon.png
 

--- a/src-tauri/src/manager.rs
+++ b/src-tauri/src/manager.rs
@@ -390,9 +390,11 @@ fn discover_modules() -> BTreeMap<String, PathBuf> {
     let path = env::var_os("PATH").unwrap_or_default();
     let mut paths = env::split_paths(&path).collect::<Vec<_>>();
 
-    if !paths.contains(&config.defaults.discovery_path) {
-        // add to the front of the path list
-        paths.insert(0, config.defaults.discovery_path.to_owned());
+    // check each path in discovery_paths and add it to the start of the paths list if it's not already there
+    for path in config.defaults.discovery_paths.iter() {
+        if !paths.contains(path) {
+            paths.insert(0, path.to_owned());
+        }
     }
 
     // Create new PATH-like string
@@ -437,8 +439,11 @@ fn discover_modules() -> BTreeMap<String, PathBuf> {
     let path = env::var_os("PATH").unwrap_or_default();
     let mut paths = env::split_paths(&path).collect::<Vec<_>>();
 
-    if !paths.contains(&config.defaults.discovery_path) {
-        paths.insert(0, config.defaults.discovery_path.to_owned());
+    // check each path in discovery_paths and add it to the start of the paths list if it's not already there
+    for path in config.defaults.discovery_paths.iter() {
+        if !paths.contains(path) {
+            paths.insert(0, path.to_owned());
+        }
     }
 
     let new_paths = env::join_paths(paths).unwrap_or_default();


### PR DESCRIPTION
Closes #64 #78 
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Support multiple discovery paths for module discovery by replacing `discovery_path` with `discovery_paths` in `Defaults` and updating `discover_modules()` in `manager.rs`.
> 
>   - **Behavior**:
>     - Replaces `discovery_path` with `discovery_paths` in `Defaults` struct in `lib.rs` to support multiple paths.
>     - Updates `discover_modules()` in `manager.rs` to iterate over `discovery_paths` and add them to the PATH if not present.
>   - **Makefile**:
>     - Changes `make` to `make build` for `aw-webui` subproject.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ActivityWatch%2Faw-tauri&utm_source=github&utm_medium=referral)<sup> for 2c2106a2276a81c65706a6bd2542b13438e78104. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->