### PR TITLE
fix: use correct logpath

### DIFF
--- a/src-tauri/src/logging.rs
+++ b/src-tauri/src/logging.rs
@@ -5,8 +5,10 @@ use std::path::PathBuf;
 
 pub fn setup_logging() -> Result<(), fern::InitError> {
     let log_path = get_log_path();
-    std::fs::create_dir_all(&log_path)?;
-    let log_file = log_path.join("aw-tauri.log");
+    let log_dir = log_path.parent().expect("Failed to get log dir");
+    if !log_dir.exists() {
+        std::fs::create_dir_all(log_dir)?;
+    }
 
     // Configure colors for log levels
     let colors = ColoredLevelConfig::new()
@@ -33,7 +35,7 @@ pub fn setup_logging() -> Result<(), fern::InitError> {
         .level_for("aw_server", LevelFilter::Info);
 
     // Configure output to file
-    let file = fern::log_file(log_file)?;
+    let file = fern::log_file(log_path)?;
 
     // Build the final dispatcher
     base_config


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes logging path issue in `setup_logging()` by ensuring the log directory exists before file creation.
> 
>   - **Behavior**:
>     - Fixes logging path issue in `setup_logging()` in `logging.rs` by ensuring the log directory exists before creating the log file.
>     - Uses `log_path.parent()` to get the directory and checks existence with `log_dir.exists()`.
>     - Creates directory with `std::fs::create_dir_all(log_dir)` if it does not exist.
>   - **Misc**:
>     - Updates `fern::log_file` to use `log_path` directly instead of `log_file`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ActivityWatch%2Faw-tauri&utm_source=github&utm_medium=referral)<sup> for 9890cba21c33db9779f32cbfa8495968400e2dd9. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->