### PR TITLE
feat: no restarts on user initiated module exits

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -474,7 +474,7 @@ pub fn run() {
                         window.show().unwrap();
                     } else if event.id().0 == "quit" {
                         println!("quit clicked!");
-                        let state = manager_state.lock().unwrap();
+                        let mut state = manager_state.lock().unwrap();
                         state.stop_modules();
                         app.exit(0);
                     } else if event.id().0 == "config_folder" {

--- a/src-tauri/src/logging.rs
+++ b/src-tauri/src/logging.rs
@@ -6,9 +6,7 @@ use std::path::PathBuf;
 pub fn setup_logging() -> Result<(), fern::InitError> {
     let log_path = get_log_path();
     let log_dir = log_path.parent().expect("Failed to get log dir");
-    if !log_dir.exists() {
-        std::fs::create_dir_all(log_dir)?;
-    }
+    std::fs::create_dir_all(log_dir)?;
 
     // Configure colors for log levels
     let colors = ColoredLevelConfig::new()


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Prevent module restarts on user-initiated exits by tracking pending shutdowns in `ManagerState`.
> 
>   - **Behavior**:
>     - Prevents module restarts on user-initiated exits by adding `modules_pending_shutdown` in `ManagerState` in `manager.rs`.
>     - Modifies `stop_module()` and `stop_modules()` in `manager.rs` to update `modules_pending_shutdown`.
>     - Updates restart logic in `handle()` in `manager.rs` to check `modules_pending_shutdown`.
>   - **Logging**:
>     - Adds warning log for config parsing errors in `get_config()` in `lib.rs`.
>     - Removes unnecessary directory existence check in `setup_logging()` in `logging.rs`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ActivityWatch%2Faw-tauri&utm_source=github&utm_medium=referral)<sup> for 878a7945572430fdfd314ed9190a6459af6c202f. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->