### PR TITLE
ci: fix appimage builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,8 +16,8 @@ jobs:
       matrix:
         include:
           - platform: 'macos-latest'
-          - platform: 'ubuntu-22.04'
-          - platform: 'ubuntu-22.04-arm' # for Arm based linux.
+          - platform: 'ubuntu-24.04'
+          - platform: 'ubuntu-24.04-arm' # for Arm based linux.
           - platform: 'windows-latest'
     runs-on: ${{ matrix.platform }}
 
@@ -26,18 +26,33 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install dependencies (ubuntu only)
-        if: matrix.platform == 'ubuntu-22.04'
+        if: matrix.platform == 'ubuntu-24.04'
         # You can remove libayatana-appindicator3-dev if you don't use the system tray feature.
         run: |
           sudo apt-get update
-           sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
+          sudo apt-get install -y libappindicator3-dev librsvg2-dev patchelf
+          sudo apt install -y \
+          libwebkit2gtk-4.1-0=2.44.0-2 \
+          libwebkit2gtk-4.1-dev=2.44.0-2 \
+          libjavascriptcoregtk-4.1-0=2.44.0-2 \
+          libjavascriptcoregtk-4.1-dev=2.44.0-2 \
+          gir1.2-javascriptcoregtk-4.1=2.44.0-2 \
+          gir1.2-webkit2-4.1=2.44.0-2;
       
       - name: Install dependencies (ubuntu-arm only)
-        if: matrix.platform == 'ubuntu-22.04-arm'
+        if: matrix.platform == 'ubuntu-24.04-arm'
         # You can remove libayatana-appindicator3-dev if you don't use the system tray feature.
         run: |
           sudo apt-get update
-           sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf libgtk-3-dev xdg-utils
+          sudo apt-get install -y libappindicator3-dev librsvg2-dev patchelf
+          sudo apt install -y \
+          libwebkit2gtk-4.1-0=2.44.0-2 \
+          libwebkit2gtk-4.1-dev=2.44.0-2 \
+          libjavascriptcoregtk-4.1-0=2.44.0-2 \
+          libjavascriptcoregtk-4.1-dev=2.44.0-2 \
+          gir1.2-javascriptcoregtk-4.1=2.44.0-2 \
+          gir1.2-webkit2-4.1=2.44.0-2 \
+          xdg-utils
 
       - name: Rust setup
         uses: dtolnay/rust-toolchain@stable


### PR DESCRIPTION
#97 
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update GitHub Actions workflow to use Ubuntu 24.04 and adjust dependencies for AppImage builds.
> 
>   - **CI Workflow**:
>     - Update Ubuntu version from `22.04` to `24.04` in `release.yml` for both `ubuntu` and `ubuntu-arm` platforms.
>     - Modify dependency installation commands to specify exact versions for `libwebkit2gtk-4.1`, `libjavascriptcoregtk-4.1`, and related packages.
>     - Remove `libgtk-3-dev` from `ubuntu-arm` dependencies.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ActivityWatch%2Faw-tauri&utm_source=github&utm_medium=referral)<sup> for d894753315a47be6e921e24028a6bd5e9944d978. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->