### PR TITLE
chore: remove unnecessary javascript deps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,26 +7,8 @@
     "": {
       "name": "aw-tauri",
       "version": "0.1.0",
-      "dependencies": {
-        "@tauri-apps/api": "2.2.0",
-        "@tauri-apps/plugin-autostart": "2.2.0",
-        "@tauri-apps/plugin-dialog": "2.2.0",
-        "@tauri-apps/plugin-notification": "2.2.1",
-        "@tauri-apps/plugin-opener": "^2.2.5",
-        "@tauri-apps/plugin-shell": "2.2.0"
-      },
       "devDependencies": {
         "@tauri-apps/cli": "2.2.7"
-      }
-    },
-    "node_modules/@tauri-apps/api": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/api/-/api-2.2.0.tgz",
-      "integrity": "sha512-R8epOeZl1eJEl603aUMIGb4RXlhPjpgxbGVEaqY+0G5JG9vzV/clNlzTeqc+NLYXVqXcn8mb4c5b9pJIUDEyAg==",
-      "license": "Apache-2.0 OR MIT",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/tauri"
       }
     },
     "node_modules/@tauri-apps/cli": {
@@ -226,51 +208,6 @@
       ],
       "engines": {
         "node": ">= 10"
-      }
-    },
-    "node_modules/@tauri-apps/plugin-autostart": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-autostart/-/plugin-autostart-2.2.0.tgz",
-      "integrity": "sha512-TzVcDZdOvdot0avkpstUWJKKEl4cyxLpFB9DZZRW5zH8k+Bv8IVJmO0zyYuw+7oKlGdHOINbD/7Je7GHMViw5w==",
-      "license": "MIT OR Apache-2.0",
-      "dependencies": {
-        "@tauri-apps/api": "^2.0.0"
-      }
-    },
-    "node_modules/@tauri-apps/plugin-dialog": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-dialog/-/plugin-dialog-2.2.0.tgz",
-      "integrity": "sha512-6bLkYK68zyK31418AK5fNccCdVuRnNpbxquCl8IqgFByOgWFivbiIlvb79wpSXi0O+8k8RCSsIpOquebusRVSg==",
-      "license": "MIT OR Apache-2.0",
-      "dependencies": {
-        "@tauri-apps/api": "^2.0.0"
-      }
-    },
-    "node_modules/@tauri-apps/plugin-notification": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-notification/-/plugin-notification-2.2.1.tgz",
-      "integrity": "sha512-QF8Zod6XDhxD6xkD5nU/BjbOpJ6+3gxGCrVULOdLpvMuMSN2Z2IdObV/qgnrEJk1UamUCF1ClQUqNCbk4zTJNQ==",
-      "license": "MIT OR Apache-2.0",
-      "dependencies": {
-        "@tauri-apps/api": "^2.0.0"
-      }
-    },
-    "node_modules/@tauri-apps/plugin-opener": {
-      "version": "2.2.5",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-opener/-/plugin-opener-2.2.5.tgz",
-      "integrity": "sha512-hHsJ9RPWpZvZEPVFaL+d25gABMUMOf/A6ESXnvf/ii9guTukj58WXsAE/SOysXRIhej7kseRCxnOnIMpSCdUsQ==",
-      "license": "MIT OR Apache-2.0",
-      "dependencies": {
-        "@tauri-apps/api": "^2.0.0"
-      }
-    },
-    "node_modules/@tauri-apps/plugin-shell": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-shell/-/plugin-shell-2.2.0.tgz",
-      "integrity": "sha512-iC3Ic1hLmasoboG7BO+7p+AriSoqAwKrIk+Hpk+S/bjTQdXqbl2GbdclghI4gM32X0bls7xHzIFqhRdrlvJeaA==",
-      "license": "MIT OR Apache-2.0",
-      "dependencies": {
-        "@tauri-apps/api": "^2.0.0"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -6,14 +6,6 @@
   "scripts": {
     "tauri": "tauri"
   },
-  "dependencies": {
-    "@tauri-apps/api": "2.2.0",
-    "@tauri-apps/plugin-autostart": "2.2.0",
-    "@tauri-apps/plugin-dialog": "2.2.0",
-    "@tauri-apps/plugin-notification": "2.2.1",
-    "@tauri-apps/plugin-opener": "^2.2.5",
-    "@tauri-apps/plugin-shell": "2.2.0"
-  },
   "devDependencies": {
     "@tauri-apps/cli": "2.2.7"
   }


### PR DESCRIPTION
Turns out these dependencies since we dropped the default tauri UI.