### PR TITLE
fix: use glob for nested directory searches

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -491,6 +491,7 @@ dependencies = [
  "chrono",
  "directories",
  "fern 0.7.1",
+ "glob",
  "lazy_static",
  "log",
  "nix",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -39,6 +39,7 @@ chrono = "0.4.39"
 aw-server = { git = "https://github.com/ActivityWatch/aw-server-rust.git", branch = "master" }
 aw-datastore = { git = "https://github.com/ActivityWatch/aw-server-rust.git", branch = "master" }
 tauri-plugin-opener = "2"
+glob = "0.3.1"
 [target.'cfg(unix)'.dependencies]
 nix = { version = "0.29.0", features = ["process", "signal"] }
 [target.'cfg(windows)'.dependencies]


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Use `glob` crate for recursive directory searches in `discover_modules()` to enhance module discovery on Unix and Windows.
> 
>   - **Behavior**:
>     - Use `glob` crate for recursive directory searches in `discover_modules()` in `manager.rs`.
>     - Handles nested directories for module discovery on both Unix and Windows.
>   - **Dependencies**:
>     - Add `glob` crate to `Cargo.toml` and `Cargo.lock`.
>   - **Misc**:
>     - Update `discover_modules()` to use `glob` for pattern matching and filtering executables.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ActivityWatch%2Faw-tauri&utm_source=github&utm_medium=referral)<sup> for 9183d363d1fc3c1fc5b1ff9df2cf2cc809362199. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->