### PR TITLE
feat: discover modules in bundled aw-tauri

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -309,6 +309,9 @@ impl Default for UserConfig {
             discovery_paths.push(PathBuf::from(
                 "/Applications/ActivityWatch.app/Contents/MacOS",
             ));
+            discovery_paths.push(PathBuf::from(
+                "/Applications/ActivityWatch.app/Contents/Resources",
+            ));
         }
 
         UserConfig {

--- a/src-tauri/src/manager.rs
+++ b/src-tauri/src/manager.rs
@@ -413,6 +413,7 @@ fn discover_modules() -> BTreeMap<String, PathBuf> {
         "aw-qt",
         "aw-server",
         "aw-server-rust",
+        "aw-watcher-window-macos",
     ];
     let config = crate::get_config();
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Exclude `aw-watcher-window-macos` from module discovery in `discover_modules()` in `manager.rs`.
> 
>   - **Behavior**:
>     - Excludes `aw-watcher-window-macos` from module discovery in `discover_modules()` in `manager.rs`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ActivityWatch%2Faw-tauri&utm_source=github&utm_medium=referral)<sup> for 3cec938125eb04cefb459056ef1483dd7f7357ec. You can [customize](https://app.ellipsis.dev/ActivityWatch/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->