### PR TITLE
fix: limit recursive search to 3 levels deep

### DIFF
--- a/src-tauri/src/manager.rs
+++ b/src-tauri/src/manager.rs
@@ -408,7 +408,6 @@ fn start_module_thread(
 #[cfg(unix)]
 fn discover_modules() -> BTreeMap<String, PathBuf> {
     let excluded = [
-        "awk",
         "aw-tauri",
         "aw-client",
         "aw-cli",
@@ -433,14 +432,32 @@ fn discover_modules() -> BTreeMap<String, PathBuf> {
 
     env::split_paths(&new_paths)
         .flat_map(|path| {
-            let pattern = path.join("**").join("aw*").to_string_lossy().to_string();
+            // Limit recursive search to 3 levels deep
+            // Create patterns for each depth level (0, 1, 2, 3)
+            let patterns = vec![
+                path.join("aw-*").to_string_lossy().to_string(),
+                path.join("*").join("aw-*").to_string_lossy().to_string(),
+                path.join("*")
+                    .join("*")
+                    .join("aw-*")
+                    .to_string_lossy()
+                    .to_string(),
+                path.join("*")
+                    .join("*")
+                    .join("*")
+                    .join("aw-*")
+                    .to_string_lossy()
+                    .to_string(),
+            ];
 
-            // Use glob to find all matching files (with recursive=true)
-            glob(&pattern)
-                .ok()
-                .into_iter()
-                .flatten()
-                .filter_map(Result::ok)
+            // Collect results from all patterns
+            patterns.into_iter().flat_map(|pattern| {
+                glob(&pattern)
+                    .ok()
+                    .into_iter()
+                    .flatten()
+                    .filter_map(Result::ok)
+            })
         })
         .filter_map(|path| {
             let file_name = path.file_name()?.to_str()?.to_string();
@@ -469,7 +486,6 @@ fn discover_modules() -> BTreeMap<String, PathBuf> {
 #[cfg(windows)]
 fn discover_modules() -> BTreeMap<String, PathBuf> {
     let excluded = [
-        "awk",
         "aw-tauri",
         "aw-client",
         "aw-cli",
@@ -493,14 +509,32 @@ fn discover_modules() -> BTreeMap<String, PathBuf> {
 
     env::split_paths(&new_paths)
         .flat_map(|path| {
-            let pattern = path.join("**").join("aw*").to_string_lossy().to_string();
+            // Limit recursive search to 3 levels deep
+            // Create patterns for each depth level (0, 1, 2, 3)
+            let patterns = vec![
+                path.join("aw-*").to_string_lossy().to_string(),
+                path.join("*").join("aw-*").to_string_lossy().to_string(),
+                path.join("*")
+                    .join("*")
+                    .join("aw-*")
+                    .to_string_lossy()
+                    .to_string(),
+                path.join("*")
+                    .join("*")
+                    .join("*")
+                    .join("aw*")
+                    .to_string_lossy()
+                    .to_string(),
+            ];
 
-            // Use glob to find all matching files (with recursive=true)
-            glob(&pattern)
-                .ok()
-                .into_iter()
-                .flatten()
-                .filter_map(Result::ok)
+            // Collect results from all patterns
+            patterns.into_iter().flat_map(|pattern| {
+                glob(&pattern)
+                    .ok()
+                    .into_iter()
+                    .flatten()
+                    .filter_map(Result::ok)
+            })
         })
         .filter_map(|path| {
             let file_name = path.file_name()?.to_str()?.to_string();


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Limit recursive search depth to 3 levels in `discover_modules()` and remove 'awk' from exclusions in `manager.rs`.
> 
>   - **Behavior**:
>     - Limit recursive search depth to 3 levels in `discover_modules()` for both Unix and Windows.
>     - Remove 'awk' from the excluded modules list in `discover_modules()`.
>   - **Misc**:
>     - Minor refactoring in `discover_modules()` to handle search patterns.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ActivityWatch%2Faw-tauri&utm_source=github&utm_medium=referral)<sup> for 3297e036de46456132c6f7f1645c479992115286. You can [customize](https://app.ellipsis.dev/ActivityWatch/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->