### PR TITLE
refactor: refactor module discovery similar to aw-qt

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ ifeq ($(shell uname -m), arm64)
 else
 	ARCH :=
 endif
+OS := $(shell uname)
 
 build: prebuild
 	npm run tauri build
@@ -35,7 +36,7 @@ package:
 	rm -rf target/package
 	mkdir -p target/package
 	# Copy binary
-ifeq ($(OS),linux)
+ifeq ($OS),linux)
 	cp src-tauri/target/release/bundle/deb/*.deb target/package/aw-tauri$(ARCH).deb
 	cp src-tauri/target/release/bundle/rpm/*.rpm target/package/aw-tauri$(ARCH).rpm
 	cp src-tauri/target/release/bundle/appimage/*.AppImage target/package/aw-tauri$(ARCH).AppImage


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Refactor `discover_modules()` in `manager.rs` to use depth-first search for module discovery, improving efficiency and reliability.
> 
>   - **Behavior**:
>     - Refactor `discover_modules()` in `manager.rs` to use depth-first search for module discovery instead of glob patterns.
>     - Handles directories and executable files starting with `aw-`, excluding certain predefined names.
>     - On Windows, strips `.exe` suffix and checks for executables.
>   - **Collections**:
>     - Adds `HashSet` to track visited directories in `discover_modules()`.
>   - **Imports**:
>     - Removes `glob` import from `manager.rs`.
>     - Adds `HashSet` to imports in `manager.rs`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ActivityWatch%2Faw-tauri&utm_source=github&utm_medium=referral)<sup> for de625f1f24141f605b7ab359ba367277eb9663b3. You can [customize](https://app.ellipsis.dev/ActivityWatch/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->