### PR TITLE
fix: fix incorrect OS parsing in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ ifeq ($(shell uname -m), arm64)
 else
 	ARCH :=
 endif
-OS := $(shell uname)
+OS := $(shell uname -s)
 
 build: prebuild
 	npm run tauri build


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix OS parsing in `Makefile` by using `uname -s` to correctly determine the operating system name.
> 
>   - **Makefile**:
>     - Fix OS parsing by changing `OS := $(shell uname)` to `OS := $(shell uname -s)` to correctly determine the operating system name.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ActivityWatch%2Faw-tauri&utm_source=github&utm_medium=referral)<sup> for 43a6ee7ad2c8ca83be4e32d7026b324b4b96a175. You can [customize](https://app.ellipsis.dev/ActivityWatch/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->