### PR TITLE
make:package rpm,appimage and deb into a folder on linux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,9 +37,9 @@ package:
 	mkdir -p target/package
 	# Copy binary
 ifeq ($(OS),Linux)
-	cp src-tauri/target/release/bundle/deb/*.deb target/package/aw-tauri$(ARCH).deb
-	cp src-tauri/target/release/bundle/rpm/*.rpm target/package/aw-tauri$(ARCH).rpm
-	cp src-tauri/target/release/bundle/appimage/*.AppImage target/package/aw-tauri$(ARCH).AppImage
+	cp src-tauri/target/release/bundle/deb/*.deb target/package/aw-tauri/aw-tauri$(ARCH).deb
+	cp src-tauri/target/release/bundle/rpm/*.rpm target/package/aw-tauri/aw-tauri$(ARCH).rpm
+	cp src-tauri/target/release/bundle/appimage/*.AppImage target/package/aw-tauri/aw-tauri$(ARCH).AppImage
 
 	mkdir -p dist/aw-tauri
 	rm -rf dist/aw-tauri/*


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Organizes Linux package files into `target/package/aw-tauri` in `Makefile`.
> 
>   - **Makefile Changes**:
>     - For Linux, package files (`.deb`, `.rpm`, `.AppImage`) are now copied to `target/package/aw-tauri/` instead of `target/package/`.
>     - Affects lines 40-42 in `Makefile`.
>   - **Behavior**:
>     - Organizes Linux package files into a subdirectory `aw-tauri` within `target/package`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ActivityWatch%2Faw-tauri&utm_source=github&utm_medium=referral)<sup> for 5f96ca869fae8dcd07c2df48260258b0c7a21fb8. You can [customize](https://app.ellipsis.dev/ActivityWatch/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->