### PR TITLE
make:package rpm,appimage and deb into a folder on linux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,11 +32,9 @@ check:
 	cd src-tauri && cargo check && cargo clippy
 
 package:
-	# Clean and prepare target/package folder
-	rm -rf target/package
-	mkdir -p target/package
-	# Copy binary
 ifeq ($(OS),Linux)
+	rm -rf target/package/aw-tauri
+	mkdir -p target/package/aw-tauri
 	cp src-tauri/target/release/bundle/deb/*.deb target/package/aw-tauri/aw-tauri$(ARCH).deb
 	cp src-tauri/target/release/bundle/rpm/*.rpm target/package/aw-tauri/aw-tauri$(ARCH).rpm
 	cp src-tauri/target/release/bundle/appimage/*.AppImage target/package/aw-tauri/aw-tauri$(ARCH).AppImage
@@ -45,6 +43,8 @@ ifeq ($(OS),Linux)
 	rm -rf dist/aw-tauri/*
 	cp target/package/aw-tauri/ dist/aw-tauri/
 else
+	rm -rf target/package
+	mkdir -p target/package
 	cp src-tauri/target/release/aw-tauri target/package/aw-tauri
 
 	mkdir -p dist


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Organize Linux packages into `target/package/aw-tauri` in `Makefile` for `.deb`, `.rpm`, and `.AppImage` files.
> 
>   - **Makefile Changes**:
>     - Modify `package` target to organize Linux packages into `target/package/aw-tauri`.
>     - Remove and recreate `target/package/aw-tauri` directory for Linux builds.
>     - Copy `.deb`, `.rpm`, and `.AppImage` files to `target/package/aw-tauri` with architecture suffix.
>     - No changes for non-Linux systems, retains existing behavior.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ActivityWatch%2Faw-tauri&utm_source=github&utm_medium=referral)<sup> for f02bc3b4aeb96b05e05e60d088487eb17be909ed. You can [customize](https://app.ellipsis.dev/ActivityWatch/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->