### PR TITLE
fix: fix packaging on linux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ ifeq ($(OS),Linux)
 
 	mkdir -p dist/aw-tauri
 	rm -rf dist/aw-tauri/*
-	cp target/package/aw-tauri/ dist/aw-tauri/
+	cp target/package/aw-tauri/* dist/aw-tauri/
 else
 	rm -rf target/package
 	mkdir -p target/package


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix `cp` command in `Makefile` for Linux packaging to include all necessary files in the distribution.
> 
>   - **Makefile**:
>     - Fix `cp` command in `package` target for Linux to copy all files from `target/package/aw-tauri/` to `dist/aw-tauri/`.
>     - Ensures all necessary files are included in the Linux distribution package.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ActivityWatch%2Faw-tauri&utm_source=github&utm_medium=referral)<sup> for d00239b2c9b84ba3c9f49d2446a16b791f3ee8e4. You can [customize](https://app.ellipsis.dev/ActivityWatch/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->