### PR TITLE
feat:aw-notify integration

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -533,7 +533,8 @@ pub fn run() {
                 let menu =
                     Menu::with_items(app, &[&open, &quit]).expect("failed to create tray menu");
 
-                let mut tray_builder = TrayIconBuilder::new()
+                #[cfg(not(target_os = "windows"))]
+                let tray_builder = TrayIconBuilder::new()
                     .icon(
                         app.default_window_icon()
                             .expect("failed to get window icon")
@@ -543,10 +544,15 @@ pub fn run() {
                     .show_menu_on_left_click(true);
 
                 #[cfg(target_os = "windows")]
-                {
-                    tray_builder = tray_builder.tooltip("ActivityWatch");
-                }
-
+                let tray_builder = TrayIconBuilder::new()
+                    .icon(
+                        app.default_window_icon()
+                            .expect("failed to get window icon")
+                            .clone(),
+                    )
+                    .menu(&menu)
+                    .show_menu_on_left_click(true)
+                    .tooltip("ActivityWatch");
                 let tray = tray_builder.build(app).expect("failed to create tray");
 
                 init_tray_id(tray.id().clone());


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Integrates `aw-notify` with special handling for notifications and updates module management in `lib.rs` and `manager.rs`.
> 
>   - **Behavior**:
>     - Integrates `aw-notify` module with special handling in `start_notify_module_thread()` in `manager.rs`.
>     - Adds `--output-only` flag for `aw-notify` and parses notifications from its output.
>     - Sends parsed notifications using `send_notification()`.
>   - **Configuration**:
>     - Updates `UserConfig` in `lib.rs` to conditionally include `aw-awatcher` or traditional watchers based on Linux display server.
>     - Adds `aw-sync` module to default configuration.
>   - **Logging**:
>     - Adds logging for module discovery and execution in `manager.rs`.
>     - Logs notification boundaries and content for `aw-notify` output.
>   - **Misc**:
>     - Adds environment variable checks for Wayland in `lib.rs`.
>     - Updates tray menu dynamically based on module state in `manager.rs`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ActivityWatch%2Faw-tauri&utm_source=github&utm_medium=referral)<sup> for 72fc490e215bda93419aef9013c1e867b4f58348. You can [customize](https://app.ellipsis.dev/ActivityWatch/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->