### PR TITLE
feat: add tooltip for windows build

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -533,14 +533,21 @@ pub fn run() {
                 let menu =
                     Menu::with_items(app, &[&open, &quit]).expect("failed to create tray menu");
 
-                let tray = TrayIconBuilder::new()
+                let mut tray_builder = TrayIconBuilder::new()
                     .icon(
                         app.default_window_icon()
                             .expect("failed to get window icon")
                             .clone(),
                     )
                     .menu(&menu)
-                    .show_menu_on_left_click(true)
+                    .show_menu_on_left_click(true);
+
+                #[cfg(target_os = "windows")]
+                {
+                    tray_builder = tray_builder.tooltip("ActivityWatch");
+                }
+
+                let tray = tray_builder
                     .build(app)
                     .expect("failed to create tray");
 


### PR DESCRIPTION
The windows build was missing a tooltip on hover. This fixes that. 

Before:

<img width="129" height="140" alt="image" src="https://github.com/user-attachments/assets/a7227cc6-4478-4e33-9e8a-70fb572a524b" />

After:

<img width="126" height="129" alt="image" src="https://github.com/user-attachments/assets/d1af9a84-ad1b-4751-ab4d-44697e12a3e2" />
