### PR TITLE
feat: update logging paths to follow AW convention

### DIFF
--- a/src-tauri/src/logging.rs
+++ b/src-tauri/src/logging.rs
@@ -1,4 +1,5 @@
-use directories::ProjectDirs;
+#[allow(unused_imports)]
+use directories::{ProjectDirs, UserDirs};
 use fern::colors::{Color, ColoredLevelConfig};
 use log::LevelFilter;
 use std::path::PathBuf;
@@ -65,8 +66,49 @@ pub fn setup_logging() -> Result<(), fern::InitError> {
 }
 
 pub fn get_log_path() -> PathBuf {
-    // TODO: creates an aw-tauri folder in linux, move inside the legacy activitywatch folder
-    let project_dirs =
-        ProjectDirs::from("net", "ActivityWatch", "Aw-Tauri").expect("Failed to get project dirs");
-    project_dirs.data_dir().join("logs").join("aw-tauri.log")
+    #[cfg(target_os = "windows")]
+    {
+        // Windows: C:\Users\<USER>\AppData\Local\activitywatch\activitywatch\Logs\aw-tauri
+        let user_dirs = UserDirs::new().expect("Failed to get user directories");
+        let home_dir = user_dirs.home_dir();
+        home_dir
+            .join("AppData")
+            .join("Local")
+            .join("activitywatch")
+            .join("activitywatch")
+            .join("Logs")
+            .join("aw-tauri")
+            .join("aw-tauri.log")
+    }
+    #[cfg(target_os = "macos")]
+    {
+        // macOS: ~/Library/Logs/activitywatch/aw-tauri
+        let user_dirs = UserDirs::new().expect("Failed to get user directories");
+        let home_dir = user_dirs.home_dir();
+        home_dir
+            .join("Library")
+            .join("Logs")
+            .join("activitywatch")
+            .join("aw-tauri")
+            .join("aw-tauri.log")
+    }
+    #[cfg(target_os = "linux")]
+    {
+        // Linux: ~/.cache/activitywatch/logs/aw-tauri/
+        let user_dirs = UserDirs::new().expect("Failed to get user directories");
+        let home_dir = user_dirs.home_dir();
+        home_dir
+            .join(".cache")
+            .join("activitywatch")
+            .join("logs")
+            .join("aw-tauri")
+            .join("aw-tauri.log")
+    }
+    #[cfg(not(any(target_os = "windows", target_os = "macos", target_os = "linux")))]
+    {
+        // Fallback for other platforms
+        let project_dirs = ProjectDirs::from("net", "ActivityWatch", "Aw-Tauri")
+            .expect("Failed to get project dirs");
+        project_dirs.data_dir().join("logs").join("aw-tauri.log")
+    }
 }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update `get_log_path()` in `logging.rs` to follow ActivityWatch log path conventions for Windows, macOS, and Linux.
> 
>   - **Behavior**:
>     - Updates `get_log_path()` in `logging.rs` to follow ActivityWatch convention for log storage paths.
>     - Windows: Logs stored in `C:\Users\<USER>\AppData\Local\activitywatch\activitywatch\Logs\aw-tauri\aw-tauri.log`.
>     - macOS: Logs stored in `~/Library/Logs/activitywatch/aw-tauri/aw-tauri.log`.
>     - Linux: Logs stored in `~/.cache/activitywatch/logs/aw-tauri/aw-tauri.log`.
>     - Fallback for other platforms uses `ProjectDirs` to determine log path.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ActivityWatch%2Faw-tauri&utm_source=github&utm_medium=referral)<sup> for c7d0b2f7eee786de0e8ba536dbb31538cba39825. You can [customize](https://app.ellipsis.dev/ActivityWatch/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->