### PR TITLE
fix: respect XDG directory rules

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -486,10 +486,10 @@ dependencies = [
 name = "aw-tauri"
 version = "0.1.0"
 dependencies = [
+ "appdirs",
  "aw-datastore",
  "aw-server",
  "chrono",
- "directories",
  "fern 0.7.1",
  "glob",
  "lazy_static",
@@ -1158,15 +1158,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "directories"
-version = "6.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16f5094c54661b38d03bd7e50df373292118db60b585c08a411c6d840017fe7d"
-dependencies = [
- "dirs-sys 0.5.0",
-]
-
-[[package]]
 name = "dirs"
 version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1201,7 +1192,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
 dependencies = [
  "libc",
- "redox_users 0.4.6",
+ "redox_users",
  "winapi 0.3.9",
 ]
 
@@ -1213,20 +1204,8 @@ checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
 dependencies = [
  "libc",
  "option-ext",
- "redox_users 0.4.6",
+ "redox_users",
  "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "dirs-sys"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
-dependencies = [
- "libc",
- "option-ext",
- "redox_users 0.5.0",
- "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1236,7 +1215,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
 dependencies = [
  "libc",
- "redox_users 0.4.6",
+ "redox_users",
  "winapi 0.3.9",
 ]
 
@@ -4029,17 +4008,6 @@ dependencies = [
  "getrandom 0.2.15",
  "libredox",
  "thiserror 1.0.69",
-]
-
-[[package]]
-name = "redox_users"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd6f9d3d47bdd2ad6945c5015a226ec6155d0bcdfd8f7cd29f86b71f8de99d2b"
-dependencies = [
- "getrandom 0.2.15",
- "libredox",
- "thiserror 2.0.6",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -28,7 +28,7 @@ tauri-plugin-notification = "2.2.1"
 tauri-plugin-single-instance = "2.2.1"
 
 notify = "8.0.0"
-directories = "6.0.0"
+appdirs = "0.2.0"
 serde = { version = "1.0.217", features = ["derive"] }
 serde_json = "1.0.140"
 toml = "0.8.19"

--- a/src-tauri/src/dirs.rs
+++ b/src-tauri/src/dirs.rs
@@ -1,0 +1,220 @@
+//! Directory management for ActivityWatch Tauri
+//!
+//! Supported platforms: Windows, Linux, macOS, Android
+
+use std::fs;
+use std::path::PathBuf;
+
+#[cfg(target_os = "android")]
+use std::sync::Mutex;
+
+#[cfg(target_os = "android")]
+use lazy_static::lazy_static;
+
+#[cfg(target_os = "android")]
+lazy_static! {
+    static ref ANDROID_DATA_DIR: Mutex<PathBuf> = Mutex::new(PathBuf::from(
+        "/data/user/0/net.activitywatch.android/files"
+    ));
+}
+
+#[cfg(not(target_os = "android"))]
+pub fn get_config_dir() -> Result<PathBuf, ()> {
+    let mut dir = appdirs::user_config_dir(Some("activitywatch"), None, false)?;
+    dir.push("aw-tauri");
+    fs::create_dir_all(dir.clone()).expect("Unable to create config dir");
+    Ok(dir)
+}
+
+#[cfg(target_os = "android")]
+pub fn get_config_dir() -> Result<PathBuf, ()> {
+    panic!("not implemented on Android");
+}
+
+#[cfg(not(target_os = "android"))]
+pub fn get_data_dir() -> Result<PathBuf, ()> {
+    let mut dir = appdirs::user_data_dir(Some("activitywatch"), None, false)?;
+    dir.push("aw-tauri");
+    fs::create_dir_all(dir.clone()).expect("Unable to create data dir");
+    Ok(dir)
+}
+
+#[cfg(target_os = "android")]
+pub fn get_data_dir() -> Result<PathBuf, ()> {
+    Ok(ANDROID_DATA_DIR.lock().unwrap().to_path_buf())
+}
+
+#[cfg(all(not(target_os = "android"), target_os = "linux"))]
+pub fn get_log_dir() -> Result<PathBuf, ()> {
+    // Linux uses cache dir for logs
+    let mut dir = appdirs::user_cache_dir(Some("activitywatch"), None)?;
+    dir.push("aw-tauri");
+    dir.push("log");
+    fs::create_dir_all(dir.clone()).expect("Unable to create log dir");
+    Ok(dir)
+}
+
+#[cfg(all(not(target_os = "android"), not(target_os = "linux")))]
+pub fn get_log_dir() -> Result<PathBuf, ()> {
+    // Windows and macOS use dedicated log directories
+    let mut dir = appdirs::user_log_dir(Some("activitywatch"), None)?;
+    dir.push("aw-tauri");
+    fs::create_dir_all(dir.clone()).expect("Unable to create log dir");
+    Ok(dir)
+}
+
+#[cfg(target_os = "android")]
+pub fn get_log_dir() -> Result<PathBuf, ()> {
+    panic!("not implemented on Android");
+}
+
+pub fn get_config_path() -> PathBuf {
+    let mut path = get_config_dir().expect("Failed to get config dir");
+    path.push("config.toml");
+    path
+}
+
+pub fn get_log_path() -> PathBuf {
+    let mut path = get_log_dir().expect("Failed to get log dir");
+    path.push("aw-tauri.log");
+    path
+}
+
+#[cfg(target_os = "linux")]
+pub fn get_runtime_dir() -> PathBuf {
+    // Linux: use XDG_RUNTIME_DIR or fallback to cache dir
+    if let Ok(runtime_dir) = std::env::var("XDG_RUNTIME_DIR") {
+        let mut dir = PathBuf::from(runtime_dir);
+        dir.push("activitywatch");
+        dir.push("aw-tauri");
+        if let Ok(_) = fs::create_dir_all(dir.clone()) {
+            return dir;
+        }
+    }
+    // Fallback to cache dir
+    let mut dir = appdirs::user_cache_dir(Some("activitywatch"), None)
+        .unwrap_or_else(|_| PathBuf::from("/tmp"));
+    dir.push("aw-tauri");
+    let _ = fs::create_dir_all(dir.clone());
+    dir
+}
+
+#[cfg(any(target_os = "windows", target_os = "macos"))]
+pub fn get_runtime_dir() -> PathBuf {
+    // For Windows and macOS, use data directory for runtime files
+    get_data_dir().unwrap_or_else(|_| PathBuf::from("."))
+}
+
+#[cfg(target_os = "android")]
+pub fn get_runtime_dir() -> PathBuf {
+    get_data_dir().unwrap_or_else(|_| PathBuf::from("/tmp"))
+}
+
+pub fn get_discovery_paths() -> Vec<PathBuf> {
+    let mut discovery_paths = Vec::new();
+
+    #[cfg(target_os = "linux")]
+    {
+        // Linux: XDG-compliant paths
+        if let Ok(home_dir) = std::env::var("HOME") {
+            let home_path = PathBuf::from(&home_dir);
+
+            // User executables directories
+            discovery_paths.push(home_path.join("bin")); // ~/bin (traditional)
+            discovery_paths.push(home_path.join(".local").join("bin")); // ~/.local/bin (modern XDG)
+
+            // XDG_DATA_HOME or ~/.local/share (user data)
+            let data_dir = std::env::var("XDG_DATA_HOME")
+                .map(PathBuf::from)
+                .unwrap_or_else(|_| home_path.join(".local").join("share"));
+            discovery_paths.push(
+                data_dir
+                    .join("activitywatch")
+                    .join("aw-tauri")
+                    .join("modules"),
+            );
+
+            // Legacy path for backward compatibility
+            discovery_paths.push(home_path.join("aw-modules"));
+        }
+    }
+
+    #[cfg(target_os = "windows")]
+    {
+        // Windows: User-specific and system paths
+        if let Ok(username) = std::env::var("USERNAME") {
+            discovery_paths.push(PathBuf::from(format!(r"C:/Users/{}/aw-modules", username)));
+            discovery_paths.push(PathBuf::from(format!(
+                r"C:/Users/{}/AppData/Local/Programs/ActivityWatch",
+                username
+            )));
+        }
+    }
+
+    #[cfg(target_os = "macos")]
+    {
+        // macOS: Application bundle and user paths
+        if let Ok(home_dir) = std::env::var("HOME") {
+            discovery_paths.push(PathBuf::from(home_dir).join("aw-modules"));
+        }
+        discovery_paths.push(PathBuf::from(
+            "/Applications/ActivityWatch.app/Contents/MacOS",
+        ));
+        discovery_paths.push(PathBuf::from(
+            "/Applications/ActivityWatch.app/Contents/Resources",
+        ));
+    }
+
+    #[cfg(target_os = "android")]
+    {
+        // Android: No discovery paths needed for mobile platform
+    }
+
+    discovery_paths
+}
+
+#[cfg(target_os = "android")]
+pub fn set_android_data_dir(path: &str) {
+    let mut android_data_dir = ANDROID_DATA_DIR.lock().unwrap();
+    *android_data_dir = PathBuf::from(path);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_get_dirs() {
+        #[cfg(target_os = "android")]
+        set_android_data_dir("/test");
+
+        #[cfg(not(target_os = "android"))]
+        {
+            get_config_dir().unwrap();
+            get_log_dir().unwrap();
+        }
+
+        get_data_dir().unwrap();
+
+        let _ = get_config_path();
+        let _ = get_log_path();
+        let _ = get_runtime_dir();
+        let _ = get_discovery_paths();
+    }
+
+    #[test]
+    fn test_paths_exist() {
+        #[cfg(target_os = "android")]
+        set_android_data_dir("/test");
+
+        #[cfg(not(target_os = "android"))]
+        {
+            let config_path = get_config_path();
+            let log_path = get_log_path();
+
+            // The parent directories should exist after calling the functions
+            assert!(config_path.parent().unwrap().exists());
+            assert!(log_path.parent().unwrap().exists());
+        }
+    }
+}

--- a/src-tauri/src/logging.rs
+++ b/src-tauri/src/logging.rs
@@ -1,5 +1,3 @@
-#[allow(unused_imports)]
-use directories::{ProjectDirs, UserDirs};
 use fern::colors::{Color, ColoredLevelConfig};
 use log::LevelFilter;
 use std::path::PathBuf;
@@ -66,49 +64,5 @@ pub fn setup_logging() -> Result<(), fern::InitError> {
 }
 
 pub fn get_log_path() -> PathBuf {
-    #[cfg(target_os = "windows")]
-    {
-        // Windows: C:\Users\<USER>\AppData\Local\activitywatch\activitywatch\Logs\aw-tauri
-        let user_dirs = UserDirs::new().expect("Failed to get user directories");
-        let home_dir = user_dirs.home_dir();
-        home_dir
-            .join("AppData")
-            .join("Local")
-            .join("activitywatch")
-            .join("activitywatch")
-            .join("Logs")
-            .join("aw-tauri")
-            .join("aw-tauri.log")
-    }
-    #[cfg(target_os = "macos")]
-    {
-        // macOS: ~/Library/Logs/activitywatch/aw-tauri
-        let user_dirs = UserDirs::new().expect("Failed to get user directories");
-        let home_dir = user_dirs.home_dir();
-        home_dir
-            .join("Library")
-            .join("Logs")
-            .join("activitywatch")
-            .join("aw-tauri")
-            .join("aw-tauri.log")
-    }
-    #[cfg(target_os = "linux")]
-    {
-        // Linux: ~/.cache/activitywatch/logs/aw-tauri/
-        let user_dirs = UserDirs::new().expect("Failed to get user directories");
-        let home_dir = user_dirs.home_dir();
-        home_dir
-            .join(".cache")
-            .join("activitywatch")
-            .join("logs")
-            .join("aw-tauri")
-            .join("aw-tauri.log")
-    }
-    #[cfg(not(any(target_os = "windows", target_os = "macos", target_os = "linux")))]
-    {
-        // Fallback for other platforms
-        let project_dirs = ProjectDirs::from("net", "ActivityWatch", "Aw-Tauri")
-            .expect("Failed to get project dirs");
-        project_dirs.data_dir().join("logs").join("aw-tauri.log")
-    }
+    crate::dirs::get_log_path()
 }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Replaces `directories` crate with `appdirs` and introduces `dirs.rs` for XDG-compliant directory management across platforms.
> 
>   - **Behavior**:
>     - Replaces `directories` crate with `appdirs` in `Cargo.toml` to comply with XDG directory standards.
>     - Introduces `dirs.rs` for platform-specific directory management, handling config, data, log, and runtime directories.
>     - Updates `get_config_path()` and `get_runtime_path()` in `lib.rs` to use new directory functions.
>   - **Directory Management**:
>     - Implements `get_config_dir()`, `get_data_dir()`, `get_log_dir()`, and `get_runtime_dir()` in `dirs.rs` for Windows, Linux, macOS, and Android.
>     - Adds `get_discovery_paths()` in `dirs.rs` for platform-specific module discovery paths.
>   - **Misc**:
>     - Removes `directories` and `dirs-sys` packages from `Cargo.lock`.
>     - Updates `get_log_path()` in `logging.rs` to use `dirs.rs` implementation.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ActivityWatch%2Faw-tauri&utm_source=github&utm_medium=referral)<sup> for 1dc7ea3e8364e89c7ec8f168e068ee6f2f19719f. You can [customize](https://app.ellipsis.dev/ActivityWatch/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->