### PR TITLE
fix: update android path to correct bundle path

### DIFF
--- a/src-tauri/src/dirs.rs
+++ b/src-tauri/src/dirs.rs
@@ -13,9 +13,8 @@ use lazy_static::lazy_static;
 
 #[cfg(target_os = "android")]
 lazy_static! {
-    static ref ANDROID_DATA_DIR: Mutex<PathBuf> = Mutex::new(PathBuf::from(
-        "/data/user/0/net.activitywatch.android/files"
-    ));
+    static ref ANDROID_DATA_DIR: Mutex<PathBuf> =
+        Mutex::new(PathBuf::from("/data/user/0/net.activitywatch.app/files"));
 }
 
 #[cfg(not(target_os = "android"))]


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update Android data directory path in `src-tauri/src/dirs.rs` to correct bundle path.
> 
>   - **Behavior**:
>     - Update Android data directory path in `src-tauri/src/dirs.rs` from `/data/user/0/net.activitywatch.android/files` to `/data/user/0/net.activitywatch.app/files`.
>     - Affects `ANDROID_DATA_DIR` used in `get_data_dir()` for Android.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ActivityWatch%2Faw-tauri&utm_source=github&utm_medium=referral)<sup> for 7ce2aaaf720ae00c9a4eac1962fd688b1126ef2a. You can [customize](https://app.ellipsis.dev/ActivityWatch/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->