### PR TITLE
fix: fix mac autostart

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -395,7 +395,7 @@ pub fn run() {
         .plugin(tauri_plugin_notification::init())
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_autostart::init(
-            MacosLauncher::LaunchAgent,
+            MacosLauncher::AppleScript,
             Some(vec![]),
         ))
         .plugin(tauri_plugin_single_instance::init(|_app, _args, _cwd| {


### PR DESCRIPTION
Fixes #106 
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Switch MacOS autostart method to `AppleScript` in `lib.rs` to fix issue #106.
> 
>   - **Behavior**:
>     - Change MacOS autostart method from `MacosLauncher::LaunchAgent` to `MacosLauncher::AppleScript` in `run()` function in `lib.rs`.
>   - **Misc**:
>     - Fixes issue #106 related to MacOS autostart.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ActivityWatch%2Faw-tauri&utm_source=github&utm_medium=referral)<sup> for bd781ea7b52aa3410432085d2f88d5901d029e29. You can [customize](https://app.ellipsis.dev/ActivityWatch/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->