### PR TITLE
chore: replace most unwraps with expect

### DIFF
--- a/src-tauri/src/dirs.rs
+++ b/src-tauri/src/dirs.rs
@@ -40,7 +40,7 @@ pub fn get_data_dir() -> Result<PathBuf, ()> {
 
 #[cfg(target_os = "android")]
 pub fn get_data_dir() -> Result<PathBuf, ()> {
-    Ok(ANDROID_DATA_DIR.lock().unwrap().to_path_buf())
+    Ok(ANDROID_DATA_DIR.lock()..expect("Unable to create data dir").to_path_buf())
 }
 
 #[cfg(all(not(target_os = "android"), target_os = "linux"))]
@@ -174,7 +174,9 @@ pub fn get_discovery_paths() -> Vec<PathBuf> {
 
 #[cfg(target_os = "android")]
 pub fn set_android_data_dir(path: &str) {
-    let mut android_data_dir = ANDROID_DATA_DIR.lock().unwrap();
+    let mut android_data_dir = ANDROID_DATA_DIR
+        .lock()
+        .expect("Unable to acquire ANDROID_DATA_DIR lock");
     *android_data_dir = PathBuf::from(path);
 }
 
@@ -189,11 +191,11 @@ mod tests {
 
         #[cfg(not(target_os = "android"))]
         {
-            get_config_dir().unwrap();
-            get_log_dir().unwrap();
+            get_config_dir().expect("Failed to get config directory");
+            get_log_dir().expect("Failed to get log directory");
         }
 
-        get_data_dir().unwrap();
+        get_data_dir().expect("Failed to get data directory");
 
         let _ = get_config_path();
         let _ = get_log_path();


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Replaces `unwrap()` with `expect()` across the codebase for improved error handling and debugging.
> 
>   - **Error Handling**:
>     - Replace `unwrap()` with `expect()` in `src-tauri/src/dirs.rs` for `ANDROID_DATA_DIR` lock and directory creation.
>     - Replace `unwrap()` with `expect()` in `src-tauri/src/lib.rs` for `HANDLE_CONDVAR`, `TRAY_CONDVAR`, and various file operations.
>     - Replace `unwrap()` with `expect()` in `src-tauri/src/manager.rs` for `manager_state` lock and module operations.
>   - **Consistency**:
>     - Ensures all `unwrap()` calls now have descriptive error messages across the codebase.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ActivityWatch%2Faw-tauri&utm_source=github&utm_medium=referral)<sup> for 346abcbf116695cf4cdfce38240c850ebfe6d7ec. You can [customize](https://app.ellipsis.dev/ActivityWatch/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->