### PR TITLE
ci: add Windows ARM64 build support in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,8 @@ jobs:
           - platform: 'ubuntu-24.04'
           - platform: 'ubuntu-24.04-arm' # for Arm based linux.
           - platform: 'windows-latest'
+          - platform: 'windows-11-arm' # for Windows ARM64
+            args: '--target aarch64-pc-windows-msvc'
     runs-on: ${{ matrix.platform }}
 
     steps:
@@ -73,6 +75,10 @@ jobs:
 
       - name: Prebuild
         run: make prebuild
+
+      - name: Add rust target
+        if: matrix.args != null
+        run: rustup target add $(echo "${{ matrix.args }}" | cut -d' ' -f2)
 
       - name: Build the app
         uses: tauri-apps/tauri-action@v0


### PR DESCRIPTION
Fixes the Windows ARM64 CI issues raised in #80.

**Changes:**
- Add `windows-11-arm` runner to release.yml matrix for the `aarch64-pc-windows-msvc` target
  - Previously used `windows-latest` (x64 runner) for ARM64, which produces incorrect binaries
- Add `rustup target add` step for builds using non-default targets (ARM64 cross-compilation)

**Note:** The `build.yml` doesn't need the same fix since it doesn't have ARM64 targets in its matrix.