### PR TITLE
feat: open external links in system browser

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -4,14 +4,7 @@
   "version": "0.1.0",
   "identifier": "net.activitywatch.app",
   "app": {
-    "windows": [
-      {
-        "title": "aw-tauri",
-        "width": 800,
-        "height": 600,
-        "visible": false
-      }
-    ],
+    "windows": [],
     "security": {
       "csp": null
     }


### PR DESCRIPTION
## Summary

Closes #105.

- Intercepts navigation in the main webview and redirects external URLs to the system default browser
- Uses Tauri 2's `on_navigation` callback on `WebviewWindowBuilder` for event-driven interception (no polling)
- Allows localhost navigation (embedded aw-server) and internal Tauri/about URLs
- Links with `target="_blank"` are already handled by `tauri-plugin-shell`

## Implementation

The main window is now created programmatically via `WebviewWindowBuilder` (instead of declaratively in `tauri.conf.json`) to attach the `on_navigation` handler. The handler checks if the URL is local, and if not, opens it in the system browser via `tauri-plugin-opener` and blocks the webview navigation.

This supersedes #112 (draft) which used a 1-second polling approach that couldn't handle `target="_blank"` links.

## Test plan

- [x] Click an external link in aw-webui dashboard (e.g. GitHub link) — should open in system browser
- [x] Click internal navigation links (e.g. switching between Activity/Timeline views) — should work normally
- [x] Verify tray icon, close-to-tray, and single-instance behavior still work
- [ ] Test on Linux, macOS, and Windows (CI covers all three)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Intercepts navigation in the main webview to open external URLs in the system browser using Tauri's `on_navigation` callback.
> 
>   - **Behavior**:
>     - Intercepts navigation in the main webview to redirect external URLs to the system browser using `on_navigation` in `src-tauri/src/lib.rs`.
>     - Allows navigation for localhost and internal Tauri/about URLs.
>     - Links with `target="_blank"` are handled by `tauri-plugin-shell`.
>   - **Implementation**:
>     - Main window creation moved to `WebviewWindowBuilder` in `src-tauri/src/lib.rs` to attach `on_navigation` handler.
>     - Uses `tauri-plugin-opener` to open external URLs in the system browser.
>     - Removes window configuration from `tauri.conf.json`.
>   - **Misc**:
>     - Supersedes draft #112 which used polling for navigation interception.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ActivityWatch%2Faw-tauri&utm_source=github&utm_medium=referral)<sup> for dcff5788665784e950bd430360fe8619021eb855. You can [customize](https://app.ellipsis.dev/ActivityWatch/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->