### PR TITLE
feat(bundle): use tauri-native resources + dynamic bundle path detection

### DIFF
--- a/src-tauri/src/dirs.rs
+++ b/src-tauri/src/dirs.rs
@@ -177,12 +177,24 @@ pub fn get_discovery_paths() -> Vec<PathBuf> {
         if let Ok(home_dir) = std::env::var("HOME") {
             discovery_paths.push(PathBuf::from(home_dir).join("aw-modules"));
         }
-        discovery_paths.push(PathBuf::from(
-            "/Applications/ActivityWatch.app/Contents/MacOS",
-        ));
-        discovery_paths.push(PathBuf::from(
-            "/Applications/ActivityWatch.app/Contents/Resources",
-        ));
+        // Detect if running inside a .app bundle dynamically via the executable path.
+        // This replaces the previous hardcoded /Applications/ActivityWatch.app paths,
+        // which broke for non-standard install locations (e.g. ~/Downloads, CI artifacts).
+        //
+        // Structure: Contents/MacOS/aw-tauri -> go up two levels -> Contents/Resources
+        if let Ok(exe_path) = std::env::current_exe() {
+            if let Some(contents_dir) = exe_path.parent().and_then(|p| p.parent()) {
+                let resources_dir = contents_dir.join("Resources");
+                if resources_dir.exists() {
+                    // Running inside a macOS .app bundle.
+                    // Modules bundled via tauri.conf.json `bundle.resources` land in Resources/modules/.
+                    discovery_paths.push(resources_dir.join("modules"));
+                    // Also include Resources/ directly for compatibility with modules placed
+                    // at the root (e.g. legacy build_app_tauri.sh layout).
+                    discovery_paths.push(resources_dir.clone());
+                }
+            }
+        }
     }
 
     #[cfg(target_os = "android")]

--- a/src-tauri/src/dirs.rs
+++ b/src-tauri/src/dirs.rs
@@ -191,7 +191,7 @@ pub fn get_discovery_paths() -> Vec<PathBuf> {
                     discovery_paths.push(resources_dir.join("modules"));
                     // Also include Resources/ directly for compatibility with modules placed
                     // at the root (e.g. legacy build_app_tauri.sh layout).
-                    discovery_paths.push(resources_dir.clone());
+                    discovery_paths.push(resources_dir);
                 }
             }
         }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -18,13 +18,6 @@
       "icons/128x128@2x.png",
       "icons/icon.icns",
       "icons/icon.ico"
-    ],
-    "resources": {
-      "../../dist/activitywatch/aw-server-rust": "modules/aw-server-rust",
-      "../../dist/activitywatch/aw-watcher-afk": "modules/aw-watcher-afk",
-      "../../dist/activitywatch/aw-watcher-window": "modules/aw-watcher-window",
-      "../../dist/activitywatch/aw-watcher-input": "modules/aw-watcher-input",
-      "../../dist/activitywatch/aw-notify": "modules/aw-notify"
-    }
+    ]
   }
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -18,6 +18,13 @@
       "icons/128x128@2x.png",
       "icons/icon.icns",
       "icons/icon.ico"
-    ]
+    ],
+    "resources": {
+      "../../dist/activitywatch/aw-server-rust": "modules/aw-server-rust",
+      "../../dist/activitywatch/aw-watcher-afk": "modules/aw-watcher-afk",
+      "../../dist/activitywatch/aw-watcher-window": "modules/aw-watcher-window",
+      "../../dist/activitywatch/aw-watcher-input": "modules/aw-watcher-input",
+      "../../dist/activitywatch/aw-notify": "modules/aw-notify"
+    }
   }
 }


### PR DESCRIPTION
## Summary

Replace the hardcoded `/Applications/ActivityWatch.app/Contents/...` discovery paths with runtime detection via `current_exe()`, so module discovery works regardless of install location.

## Changes

### `dirs.rs` — dynamic resource path detection

Replace the hardcoded `/Applications/ActivityWatch.app/Contents/...` discovery paths with runtime detection via `current_exe()`:

```rust
// Contents/MacOS/aw-tauri  →  go up two levels  →  Contents/Resources
if let Ok(exe_path) = std::env::current_exe() {
    if let Some(contents_dir) = exe_path.parent().and_then(|p| p.parent()) {
        let resources_dir = contents_dir.join("Resources");
        if resources_dir.exists() {
            discovery_paths.push(resources_dir.join("modules")); // tauri-native layout
            discovery_paths.push(resources_dir);                  // legacy compat
        }
    }
}
```

**Why this matters**: The old code only worked when installed at `/Applications/ActivityWatch.app`. Users who move the app to `~/Applications/` or run from a downloaded DMG had no module discovery.

### `tauri.conf.json` — (reverted)

The companion `bundle.resources` config entries were removed in 1dbc66b to keep aw-tauri CI self-contained. The activitywatch build system injects resources at build time via `--config`.

## What was verified

- Greptile P1 (Contents/MacOS path drop): Confirmed false positive — `build_app_tauri.sh` puts all modules in `Contents/Resources/<name>/`; `Contents/MacOS/` only contains the aw-tauri binary
- Greptile P2 (unnecessary `.clone()`): Fixed in faa6c6e

## Greptile Findings Status

| Finding | Status | Resolution |
|---------|--------|-----------|
| P1: Contents/MacOS drop | Resolved ✅ | Verified false positive — modules never placed there |
| P2: unnecessary `.clone()` | Resolved ✅ | Fixed in [faa6c6e](faa6c6e) |