### PR TITLE
fix: change identifier in tauri configuration to net.activitywatch.tauri

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "aw-tauri",
   "version": "0.1.0",
-  "identifier": "net.activitywatch.app",
+  "identifier": "net.activitywatch.tauri",
   "app": {
     "windows": [],
     "security": {


### PR DESCRIPTION
`tauri build` was emitting the warning: 

> Warn The bundle identifier "net.activitywatch.app" set in `"tauri.conf.json" identifier` ends with `.app`. This is not recommended because it conflicts with the application bundle extension on macOS."

This adresses that.