### PR TITLE
feat(auth): bootstrap aw-webui token on launch

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -359,7 +359,7 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 [[package]]
 name = "aw-client-rust"
 version = "0.1.0"
-source = "git+https://github.com/ActivityWatch/aw-server-rust.git?branch=master#b6013e46287a813ebdad60f17336c3b20c94a3f9"
+source = "git+https://github.com/ActivityWatch/aw-server-rust.git?branch=master#7c33810cd44393b3ecad64277b7e69bfeaee817b"
 dependencies = [
  "aw-models",
  "chrono",
@@ -380,7 +380,7 @@ dependencies = [
 [[package]]
 name = "aw-datastore"
 version = "0.1.0"
-source = "git+https://github.com/ActivityWatch/aw-server-rust.git?branch=master#b6013e46287a813ebdad60f17336c3b20c94a3f9"
+source = "git+https://github.com/ActivityWatch/aw-server-rust.git?branch=master#7c33810cd44393b3ecad64277b7e69bfeaee817b"
 dependencies = [
  "aw-models",
  "aw-transform",
@@ -396,7 +396,7 @@ dependencies = [
 [[package]]
 name = "aw-models"
 version = "0.1.0"
-source = "git+https://github.com/ActivityWatch/aw-server-rust.git?branch=master#b6013e46287a813ebdad60f17336c3b20c94a3f9"
+source = "git+https://github.com/ActivityWatch/aw-server-rust.git?branch=master#7c33810cd44393b3ecad64277b7e69bfeaee817b"
 dependencies = [
  "chrono",
  "log",
@@ -408,7 +408,7 @@ dependencies = [
 [[package]]
 name = "aw-query"
 version = "0.1.0"
-source = "git+https://github.com/ActivityWatch/aw-server-rust.git?branch=master#b6013e46287a813ebdad60f17336c3b20c94a3f9"
+source = "git+https://github.com/ActivityWatch/aw-server-rust.git?branch=master#7c33810cd44393b3ecad64277b7e69bfeaee817b"
 dependencies = [
  "aw-datastore",
  "aw-models",
@@ -424,7 +424,7 @@ dependencies = [
 [[package]]
 name = "aw-server"
 version = "0.13.1"
-source = "git+https://github.com/ActivityWatch/aw-server-rust.git?branch=master#b6013e46287a813ebdad60f17336c3b20c94a3f9"
+source = "git+https://github.com/ActivityWatch/aw-server-rust.git?branch=master#7c33810cd44393b3ecad64277b7e69bfeaee817b"
 dependencies = [
  "android_logger",
  "aw-client-rust",
@@ -450,6 +450,7 @@ dependencies = [
  "sd-notify",
  "serde",
  "serde_json",
+ "subtle",
  "toml 0.8.2",
  "uuid",
 ]
@@ -488,7 +489,7 @@ dependencies = [
 [[package]]
 name = "aw-transform"
 version = "0.1.0"
-source = "git+https://github.com/ActivityWatch/aw-server-rust.git?branch=master#b6013e46287a813ebdad60f17336c3b20c94a3f9"
+source = "git+https://github.com/ActivityWatch/aw-server-rust.git?branch=master#7c33810cd44393b3ecad64277b7e69bfeaee817b"
 dependencies = [
  "aw-models",
  "chrono",
@@ -2240,7 +2241,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core",
 ]
 
 [[package]]
@@ -3417,7 +3418,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -4736,7 +4737,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b1fdf65dd6331831494dd616b30351c38e96e45921a27745cf98490458b90bb"
 dependencies = [
- "dirs 6.0.0",
+ "dirs 4.0.0",
 ]
 
 [[package]]
@@ -4936,6 +4937,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
 name = "swift-rs"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5063,7 +5070,7 @@ dependencies = [
  "unicode-segmentation",
  "url",
  "windows 0.61.3",
- "windows-core 0.61.2",
+ "windows-core",
  "windows-version",
  "x11-dl",
 ]
@@ -6299,7 +6306,7 @@ dependencies = [
  "webview2-com-macros",
  "webview2-com-sys",
  "windows 0.61.3",
- "windows-core 0.61.2",
+ "windows-core",
  "windows-implement",
  "windows-interface",
 ]
@@ -6323,7 +6330,7 @@ checksum = "381336cfffd772377d291702245447a5251a2ffa5bad679c99e61bc48bacbf9c"
 dependencies = [
  "thiserror 2.0.18",
  "windows 0.61.3",
- "windows-core 0.61.2",
+ "windows-core",
 ]
 
 [[package]]
@@ -6388,7 +6395,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
 dependencies = [
  "windows-collections",
- "windows-core 0.61.2",
+ "windows-core",
  "windows-future",
  "windows-link 0.1.3",
  "windows-numerics",
@@ -6400,7 +6407,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
 dependencies = [
- "windows-core 0.61.2",
+ "windows-core",
 ]
 
 [[package]]
@@ -6412,21 +6419,8 @@ dependencies = [
  "windows-implement",
  "windows-interface",
  "windows-link 0.1.3",
- "windows-result 0.3.4",
- "windows-strings 0.4.2",
-]
-
-[[package]]
-name = "windows-core"
-version = "0.62.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
-dependencies = [
- "windows-implement",
- "windows-interface",
- "windows-link 0.2.1",
- "windows-result 0.4.1",
- "windows-strings 0.5.1",
+ "windows-result",
+ "windows-strings",
 ]
 
 [[package]]
@@ -6435,7 +6429,7 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
 dependencies = [
- "windows-core 0.61.2",
+ "windows-core",
  "windows-link 0.1.3",
  "windows-threading",
 ]
@@ -6480,7 +6474,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
 dependencies = [
- "windows-core 0.61.2",
+ "windows-core",
  "windows-link 0.1.3",
 ]
 
@@ -6494,30 +6488,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows-result"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
-dependencies = [
- "windows-link 0.2.1",
-]
-
-[[package]]
 name = "windows-strings"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
 dependencies = [
  "windows-link 0.1.3",
-]
-
-[[package]]
-name = "windows-strings"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
-dependencies = [
- "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -7016,7 +6992,7 @@ dependencies = [
  "webkit2gtk-sys",
  "webview2-com",
  "windows 0.61.3",
- "windows-core 0.61.2",
+ "windows-core",
  "windows-version",
  "x11-dl",
 ]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -42,7 +42,7 @@ use tauri::{
     menu::{Menu, MenuItem},
     tray::{TrayIconBuilder, TrayIconId},
     webview::WebviewWindowBuilder,
-    AppHandle, Manager,
+    AppHandle, Manager, Url,
 };
 
 pub struct AppHandleWrapper(Mutex<AppHandle>);
@@ -189,6 +189,17 @@ pub fn handle_first_run() {
             }
         });
     }
+}
+
+fn build_dashboard_url(port: u16, api_key: Option<&str>) -> Url {
+    let mut url =
+        Url::parse(&format!("http://localhost:{port}/")).expect("Failed to parse localhost url");
+
+    if let Some(api_key) = api_key.filter(|key| !key.is_empty()) {
+        url.query_pairs_mut().append_pair("token", api_key);
+    }
+
+    url
 }
 
 pub fn listen_for_lockfile() {
@@ -538,22 +549,31 @@ pub fn run() {
                 if testing {
                     info!("Running in testing mode (port {})", port);
                 }
+                let dashboard_api_key = aw_config
+                    .auth
+                    .api_key
+                    .as_deref()
+                    .filter(|key| !key.is_empty());
+                if dashboard_api_key.is_some() {
+                    info!("Bootstrapping aw-webui API token into dashboard URL");
+                }
+                let dashboard_url = build_dashboard_url(port, dashboard_api_key);
                 tauri::async_runtime::spawn(build_rocket(server_state, aw_config).launch());
-                let url = format!("http://localhost:{}/", port)
-                    .parse()
-                    .expect("Failed to parse localhost url");
                 // Create main window programmatically to attach initialization script.
                 // The script intercepts clicks on external links and opens them in the system
                 // browser via the open_external Tauri command. This approach works reliably for
                 // SPA-generated links where on_navigation (which only fires for top-level
                 // webview navigations) would miss JS-driven internal route changes.
-                let _main_window =
-                    WebviewWindowBuilder::new(app, "main", tauri::WebviewUrl::External(url))
-                        .title("aw-tauri")
-                        .inner_size(800.0, 600.0)
-                        .visible(false)
-                        .initialization_script(
-                            r#"
+                let _main_window = WebviewWindowBuilder::new(
+                    app,
+                    "main",
+                    tauri::WebviewUrl::External(dashboard_url),
+                )
+                .title("aw-tauri")
+                .inner_size(800.0, 600.0)
+                .visible(false)
+                .initialization_script(
+                    r#"
                     document.addEventListener('click', function(e) {
                         var el = e.target;
                         while (el && el.tagName !== 'A') { el = el.parentElement; }
@@ -564,9 +584,9 @@ pub fn run() {
                         }
                     }, true);
                     "#,
-                        )
-                        .build()
-                        .expect("Failed to create main window");
+                )
+                .build()
+                .expect("Failed to create main window");
                 let manager_state = manager::start_manager();
 
                 let open = MenuItem::with_id(app, "open", "Open Dashboard", true, None::<&str>)
@@ -655,4 +675,33 @@ pub fn run() {
         .invoke_handler(tauri::generate_handler![greet, open_external])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::build_dashboard_url;
+
+    #[test]
+    fn build_dashboard_url_omits_token_when_auth_disabled() {
+        assert_eq!(
+            build_dashboard_url(5600, None).as_str(),
+            "http://localhost:5600/"
+        );
+    }
+
+    #[test]
+    fn build_dashboard_url_ignores_empty_api_keys() {
+        assert_eq!(
+            build_dashboard_url(5600, Some("")).as_str(),
+            "http://localhost:5600/"
+        );
+    }
+
+    #[test]
+    fn build_dashboard_url_appends_encoded_token() {
+        assert_eq!(
+            build_dashboard_url(5600, Some("secret+ /?=&")).as_str(),
+            "http://localhost:5600/?token=secret%2B+%2F%3F%3D%26"
+        );
+    }
 }


### PR DESCRIPTION
## Summary
- bump `aw-server-rust` in `Cargo.lock` to the auth-aware revision
- append `?token=...` to the initial dashboard URL when `[auth].api_key` is configured
- cover the launch URL builder with focused unit tests, including query encoding

This is the `aw-tauri` leg of the ActivityWatch API auth rollout.

Related:
- ActivityWatch/activitywatch#1199
- ActivityWatch/aw-server-rust#585
- ActivityWatch/aw-webui#806

## Verification
- `cargo fmt --manifest-path src-tauri/Cargo.toml`
- `prek run fmt --files src-tauri/src/lib.rs`
- `prek run end-of-file-fixer --files src-tauri/Cargo.lock src-tauri/src/lib.rs`
- `prek run check-added-large-files --files src-tauri/Cargo.lock src-tauri/src/lib.rs`
- `cargo test --manifest-path src-tauri/Cargo.toml build_dashboard_url --lib` *(blocked locally: this machine is missing `gdk-3.0` dev libraries, so Tauri/GTK deps fail before the crate compiles)*
