### PR TITLE
feat(cli): add --daemon and --mini modes for headless/lightweight operation

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -471,9 +471,13 @@ dependencies = [
  "log",
  "nix",
  "notify",
+ "notify-rust",
+ "open",
+ "png",
  "serde",
  "serde_json",
  "shell-words",
+ "tao",
  "tauri",
  "tauri-build",
  "tauri-plugin-autostart",
@@ -484,6 +488,7 @@ dependencies = [
  "tauri-plugin-single-instance",
  "tokio",
  "toml 0.9.12+spec-1.1.0",
+ "tray-icon",
  "winapi",
 ]
 

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -482,6 +482,7 @@ dependencies = [
  "tauri-plugin-opener",
  "tauri-plugin-shell",
  "tauri-plugin-single-instance",
+ "tokio",
  "toml 0.9.12+spec-1.1.0",
  "winapi",
 ]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -28,6 +28,7 @@ tauri-plugin-dialog = "2.2.0"
 tauri-plugin-notification = "2.2.1"
 tauri-plugin-single-instance = "2.2.1"
 
+tokio = { version = "1", features = ["rt-multi-thread"] }
 notify = "8.0.0"
 dirs = "5.0.1"
 serde = { version = "1.0.217", features = ["derive"] }

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -27,9 +27,12 @@ tauri-plugin-shell = "2.2.0"
 tauri-plugin-dialog = "2.2.0"
 tauri-plugin-notification = "2.2.1"
 tauri-plugin-single-instance = "2.2.1"
+tray-icon = { version = "0.21.3", default-features = false }
+tao = "0.34.5"
 
 tokio = { version = "1", features = ["rt-multi-thread"] }
 notify = "8.0.0"
+notify-rust = "4.12.0"
 dirs = "5.0.1"
 serde = { version = "1.0.217", features = ["derive"] }
 serde_json = "1.0.140"
@@ -42,6 +45,8 @@ aw-server = { git = "https://github.com/ActivityWatch/aw-server-rust.git", branc
 aw-datastore = { git = "https://github.com/ActivityWatch/aw-server-rust.git", branch = "master" }
 tauri-plugin-opener = "2"
 glob = "0.3.1"
+open = "5.3.3"
+png = "0.17.16"
 [target.'cfg(unix)'.dependencies]
 nix = { version = "0.29.0", features = ["process", "signal"] }
 libc = "0.2"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -486,8 +486,14 @@ fn run_daemon() {
     let manager_state = manager::start_manager();
 
     // Wait for server shutdown (Rocket handles SIGINT/SIGTERM cleanly)
-    if let Err(e) = rt.block_on(rocket_handle).expect("Rocket task panicked") {
-        error!("Server exited with error: {:?}", e);
+    // Use match instead of expect so that stop_modules() always runs —
+    // even if the Rocket task panics, we clean up watcher child processes.
+    match rt.block_on(rocket_handle) {
+        Ok(Err(e)) => error!("Server exited with error: {:?}", e),
+        Err(join_err) => {
+            error!("Rocket task panicked: {:?}", join_err);
+        }
+        Ok(Ok(())) => info!("Server shutdown cleanly"),
     }
 
     info!("Server stopped, shutting down modules");

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -487,8 +487,9 @@ fn run_daemon() {
     // connecting — matches the GUI path ordering (spawn then start_manager)
     let rocket_handle = rt.spawn(build_rocket(server_state, aw_config).launch());
 
-    // Start module manager after Rocket is already starting up
-    let manager_state = manager::start_manager();
+    // Start module manager after Rocket is already starting up.
+    // Pass the CLI-computed port so --testing and --port are respected.
+    let manager_state = manager::start_manager_with_port(port);
 
     // Wait for server shutdown (Rocket handles SIGINT/SIGTERM cleanly)
     // Use match instead of expect so that stop_modules() always runs —

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -591,6 +591,7 @@ pub(crate) fn prepare_aw_server(
 
 /// Run the lightweight mini mode: tray + server, no Tauri WebView.
 pub fn run_mini() {
+    MINI_MODE.set(true).expect("MINI_MODE already set");
     mini::run();
 }
 
@@ -635,8 +636,7 @@ pub fn run() {
     }
 
     if cli_args.mini {
-        MINI_MODE.set(true).expect("MINI_MODE already set");
-        mini::run();
+        run_mini();
         return;
     }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -488,19 +488,32 @@ fn run_daemon() {
     // Wait for server shutdown (Rocket handles SIGINT/SIGTERM cleanly)
     // Use match instead of expect so that stop_modules() always runs —
     // even if the Rocket task panics, we clean up watcher child processes.
-    match rt.block_on(rocket_handle) {
-        Ok(Err(e)) => error!("Server exited with error: {:?}", e),
+    // Track whether the exit was abnormal so we can propagate a non-zero
+    // exit code after cleanup — required for systemd/Docker restart policies.
+    let exit_error = match rt.block_on(rocket_handle) {
+        Ok(Err(e)) => {
+            error!("Server exited with error: {:?}", e);
+            true
+        }
         Err(join_err) => {
             error!("Rocket task panicked: {:?}", join_err);
+            true
         }
-        Ok(Ok(_)) => info!("Server shutdown cleanly"),
-    }
+        Ok(Ok(_)) => {
+            info!("Server shutdown cleanly");
+            false
+        }
+    };
 
     info!("Server stopped, shutting down modules");
     manager_state
         .lock()
         .expect("Failed to lock manager state")
         .stop_modules();
+
+    if exit_error {
+        std::process::exit(1);
+    }
 }
 
 // Learn more about Tauri commands at https://tauri.app/develop/calling-rust/

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -493,7 +493,7 @@ fn run_daemon() {
         Err(join_err) => {
             error!("Rocket task panicked: {:?}", join_err);
         }
-        Ok(Ok(())) => info!("Server shutdown cleanly"),
+        Ok(Ok(_)) => info!("Server shutdown cleanly"),
     }
 
     info!("Server stopped, shutting down modules");

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,4 +1,7 @@
-use aw_server::endpoints::build_rocket;
+use aw_server::{
+    config::AWConfig,
+    endpoints::{build_rocket, ServerState},
+};
 use lazy_static::lazy_static;
 use notify::{Config, Event, EventKind, RecommendedWatcher, RecursiveMode, Watcher};
 use serde::{Deserialize, Serialize};
@@ -17,6 +20,7 @@ use tauri_plugin_opener::OpenerExt;
 mod dirs;
 mod logging;
 mod manager;
+mod mini;
 
 /// CLI arguments passed from main()
 #[derive(Debug, Default)]
@@ -25,6 +29,7 @@ pub struct CliArgs {
     pub verbose: bool,
     pub port: Option<u16>,
     pub daemon: bool,
+    pub mini: bool,
 }
 
 static CLI_ARGS: OnceLock<CliArgs> = OnceLock::new();
@@ -516,6 +521,72 @@ fn run_daemon() {
     }
 }
 
+/// Prepare the aw-server state, config, and dashboard URL.
+/// Shared by mini mode and the Tauri GUI mode.
+pub(crate) fn prepare_aw_server(
+    user_config: &UserConfig,
+    cli_args: &CliArgs,
+) -> Result<(Url, ServerState, AWConfig), String> {
+    let testing = cli_args.testing;
+    let legacy_import = false;
+
+    let mut aw_config = aw_server::config::create_config(testing);
+
+    // Port priority: CLI flag > testing default (5666) > config file
+    let port = cli_args
+        .port
+        .unwrap_or(if testing { 5666 } else { user_config.port });
+    aw_config.port = port;
+    let db_path = aw_server::dirs::db_path(testing)
+        .map_err(|_| "Failed to get db path".to_string())?
+        .to_str()
+        .ok_or_else(|| "Database path is not valid UTF-8".to_string())?
+        .to_string();
+    let device_id = aw_server::device_id::get_device_id();
+
+    let webui_var = std::env::var("AW_WEBUI_DIR");
+
+    let asset_path_opt = if let Ok(path_str) = &webui_var {
+        let asset_path = PathBuf::from(path_str);
+        if asset_path.exists() {
+            info!("Using webui path: {}", path_str);
+            Some(asset_path)
+        } else {
+            return Err("Path set via env var AW_WEBUI_DIR does not exist".to_string());
+        }
+    } else {
+        info!("Using bundled assets");
+        None
+    };
+
+    let server_state = ServerState {
+        datastore: Mutex::new(aw_datastore::Datastore::new(db_path, legacy_import)),
+        asset_resolver: aw_server::endpoints::AssetResolver::new(asset_path_opt),
+        device_id,
+    };
+    if !is_port_available(port).map_err(|e| format!("Failed to check port availability: {e}"))? {
+        return Err(format!("Port {} is already in use", port));
+    }
+    if testing {
+        info!("Running in testing mode (port {})", port);
+    }
+    let dashboard_api_key = aw_config
+        .auth
+        .api_key
+        .as_deref()
+        .filter(|key| !key.is_empty());
+    if dashboard_api_key.is_some() {
+        info!("Bootstrapping aw-webui API token into dashboard URL");
+    }
+    let dashboard_url = build_dashboard_url(port, dashboard_api_key);
+    Ok((dashboard_url, server_state, aw_config))
+}
+
+/// Run the lightweight mini mode: tray + server, no Tauri WebView.
+pub fn run_mini() {
+    mini::run();
+}
+
 // Learn more about Tauri commands at https://tauri.app/develop/calling-rust/
 #[tauri::command]
 fn greet(name: &str) -> String {
@@ -553,6 +624,11 @@ pub fn run() {
     if cli_args.daemon {
         DAEMON_MODE.set(true).expect("DAEMON_MODE already set");
         run_daemon();
+        return;
+    }
+
+    if cli_args.mini {
+        mini::run();
         return;
     }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -32,7 +32,7 @@ static DAEMON_MODE: OnceLock<bool> = OnceLock::new();
 
 /// Returns true when running in headless daemon mode (no Tauri/GUI).
 pub(crate) fn is_daemon_mode() -> bool {
-    *DAEMON_MODE.get_or_init(|| false)
+    DAEMON_MODE.get().copied().unwrap_or(false)
 }
 
 /// Set CLI args before calling run(). Must be called at most once.
@@ -472,16 +472,21 @@ fn run_daemon() {
 
     info!("Starting aw-tauri in daemon mode on port {port}");
 
-    // Start module manager (tray updates are no-ops in daemon mode)
-    let manager_state = manager::start_manager();
-
-    // Launch the HTTP server; Rocket handles SIGINT/SIGTERM and shuts down cleanly
+    // Build Tokio runtime first so we can spawn Rocket before starting modules
     let rt = tokio::runtime::Builder::new_multi_thread()
         .enable_all()
         .build()
         .expect("Failed to build Tokio runtime");
 
-    if let Err(e) = rt.block_on(build_rocket(server_state, aw_config).launch()) {
+    // Spawn Rocket first so it begins binding the port before watchers start
+    // connecting — matches the GUI path ordering (spawn then start_manager)
+    let rocket_handle = rt.spawn(build_rocket(server_state, aw_config).launch());
+
+    // Start module manager after Rocket is already starting up
+    let manager_state = manager::start_manager();
+
+    // Wait for server shutdown (Rocket handles SIGINT/SIGTERM cleanly)
+    if let Err(e) = rt.block_on(rocket_handle).expect("Rocket task panicked") {
         error!("Server exited with error: {:?}", e);
     }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -34,10 +34,16 @@ pub struct CliArgs {
 
 static CLI_ARGS: OnceLock<CliArgs> = OnceLock::new();
 static DAEMON_MODE: OnceLock<bool> = OnceLock::new();
+static MINI_MODE: OnceLock<bool> = OnceLock::new();
 
 /// Returns true when running in headless daemon mode (no Tauri/GUI).
 pub(crate) fn is_daemon_mode() -> bool {
     DAEMON_MODE.get().copied().unwrap_or(false)
+}
+
+/// Returns true when running in mini mode (tray + server, no Tauri WebView).
+pub(crate) fn is_mini_mode() -> bool {
+    MINI_MODE.get().copied().unwrap_or(false)
 }
 
 /// Set CLI args before calling run(). Must be called at most once.
@@ -404,7 +410,7 @@ pub(crate) fn get_config() -> &'static UserConfig {
                 Err(e) => {
                     warn!("Failed to parse config file: {}. Using default config.", e);
 
-                    if !is_daemon_mode() {
+                    if !is_daemon_mode() && !is_mini_mode() {
                         let app = &*get_app_handle().lock().expect("Failed to get app handle");
                         app.dialog()
                             .message("Malformed config file. Using default config.")
@@ -629,6 +635,7 @@ pub fn run() {
     }
 
     if cli_args.mini {
+        MINI_MODE.set(true).expect("MINI_MODE already set");
         mini::run();
         return;
     }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -452,11 +452,19 @@ fn run_daemon() {
     let mut aw_config = aw_server::config::create_config(testing);
     aw_config.port = port;
 
-    let db_path = aw_server::dirs::db_path(testing)
-        .expect("Failed to get db path")
-        .to_str()
-        .unwrap()
-        .to_string();
+    let db_path = match aw_server::dirs::db_path(testing) {
+        Ok(path) => match path.to_str() {
+            Some(s) => s.to_string(),
+            None => {
+                eprintln!("Error: database path is not valid UTF-8");
+                std::process::exit(1);
+            }
+        },
+        Err(e) => {
+            eprintln!("Error: failed to get db path: {e}");
+            std::process::exit(1);
+        }
+    };
     let device_id = aw_server::device_id::get_device_id();
 
     let asset_path_opt = match std::env::var("AW_WEBUI_DIR") {
@@ -544,6 +552,13 @@ pub(crate) fn prepare_aw_server(
         .port
         .unwrap_or(if testing { 5666 } else { user_config.port });
     aw_config.port = port;
+
+    // Check port availability before opening the datastore — opening the SQLite
+    // store acquires a lock, so bail on a busy port first (matches run_daemon's order).
+    if !is_port_available(port).map_err(|e| format!("Failed to check port availability: {e}"))? {
+        return Err(format!("Port {} is already in use", port));
+    }
+
     let db_path = aw_server::dirs::db_path(testing)
         .map_err(|_| "Failed to get db path".to_string())?
         .to_str()
@@ -571,9 +586,6 @@ pub(crate) fn prepare_aw_server(
         asset_resolver: aw_server::endpoints::AssetResolver::new(asset_path_opt),
         device_id,
     };
-    if !is_port_available(port).map_err(|e| format!("Failed to check port availability: {e}"))? {
-        return Err(format!("Port {} is already in use", port));
-    }
     if testing {
         info!("Running in testing mode (port {})", port);
     }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -460,8 +460,8 @@ fn run_daemon() {
                 std::process::exit(1);
             }
         },
-        Err(e) => {
-            eprintln!("Error: failed to get db path: {e}");
+        Err(_) => {
+            eprintln!("Error: failed to get db path");
             std::process::exit(1);
         }
     };

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -24,9 +24,16 @@ pub struct CliArgs {
     pub testing: bool,
     pub verbose: bool,
     pub port: Option<u16>,
+    pub daemon: bool,
 }
 
 static CLI_ARGS: OnceLock<CliArgs> = OnceLock::new();
+static DAEMON_MODE: OnceLock<bool> = OnceLock::new();
+
+/// Returns true when running in headless daemon mode (no Tauri/GUI).
+pub(crate) fn is_daemon_mode() -> bool {
+    *DAEMON_MODE.get_or_init(|| false)
+}
 
 /// Set CLI args before calling run(). Must be called at most once.
 pub fn set_cli_args(args: CliArgs) {
@@ -37,7 +44,7 @@ fn get_cli_args() -> &'static CliArgs {
     CLI_ARGS.get_or_init(CliArgs::default)
 }
 
-use log::{info, trace, warn};
+use log::{error, info, trace, warn};
 use tauri::{
     menu::{Menu, MenuItem},
     tray::{TrayIconBuilder, TrayIconId},
@@ -392,12 +399,14 @@ pub(crate) fn get_config() -> &'static UserConfig {
                 Err(e) => {
                     warn!("Failed to parse config file: {}. Using default config.", e);
 
-                    let app = &*get_app_handle().lock().expect("Failed to get app handle");
-                    app.dialog()
-                        .message("Malformed config file. Using default config.")
-                        .kind(MessageDialogKind::Error)
-                        .title("Error")
-                        .show(|_| {});
+                    if !is_daemon_mode() {
+                        let app = &*get_app_handle().lock().expect("Failed to get app handle");
+                        app.dialog()
+                            .message("Malformed config file. Using default config.")
+                            .kind(MessageDialogKind::Error)
+                            .title("Error")
+                            .show(|_| {});
+                    }
 
                     UserConfig::default()
                 }
@@ -411,6 +420,76 @@ pub(crate) fn get_config() -> &'static UserConfig {
             config
         }
     })
+}
+
+/// Run without a GUI: start the server and module manager, block until a signal
+/// is received, then cleanly stop all modules.
+fn run_daemon() {
+    let cli_args = get_cli_args();
+    let testing = cli_args.testing;
+
+    let config = get_config();
+    let port = cli_args
+        .port
+        .unwrap_or(if testing { 5666 } else { config.port });
+
+    if !is_port_available(port).expect("Failed to check port availability") {
+        eprintln!("Error: port {} is already in use", port);
+        std::process::exit(1);
+    }
+
+    let mut aw_config = aw_server::config::create_config(testing);
+    aw_config.port = port;
+
+    let db_path = aw_server::dirs::db_path(testing)
+        .expect("Failed to get db path")
+        .to_str()
+        .unwrap()
+        .to_string();
+    let device_id = aw_server::device_id::get_device_id();
+
+    let asset_path_opt = match std::env::var("AW_WEBUI_DIR") {
+        Ok(path_str) => {
+            let asset_path = PathBuf::from(&path_str);
+            if asset_path.exists() {
+                info!("Using webui path: {}", path_str);
+                Some(asset_path)
+            } else {
+                panic!("Path set via AW_WEBUI_DIR does not exist");
+            }
+        }
+        Err(_) => {
+            info!("Using bundled assets");
+            None
+        }
+    };
+
+    let server_state = aw_server::endpoints::ServerState {
+        datastore: Mutex::new(aw_datastore::Datastore::new(db_path, false)),
+        asset_resolver: aw_server::endpoints::AssetResolver::new(asset_path_opt),
+        device_id,
+    };
+
+    info!("Starting aw-tauri in daemon mode on port {port}");
+
+    // Start module manager (tray updates are no-ops in daemon mode)
+    let manager_state = manager::start_manager();
+
+    // Launch the HTTP server; Rocket handles SIGINT/SIGTERM and shuts down cleanly
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .expect("Failed to build Tokio runtime");
+
+    if let Err(e) = rt.block_on(build_rocket(server_state, aw_config).launch()) {
+        error!("Server exited with error: {:?}", e);
+    }
+
+    info!("Server stopped, shutting down modules");
+    manager_state
+        .lock()
+        .expect("Failed to lock manager state")
+        .stop_modules();
 }
 
 // Learn more about Tauri commands at https://tauri.app/develop/calling-rust/
@@ -445,6 +524,12 @@ pub fn run() {
     if let Err(e) = logging::setup_logging() {
         // Can't use log here since logging isn't initialized yet
         eprintln!("Failed to initialize logging: {}", e);
+    }
+
+    if cli_args.daemon {
+        DAEMON_MODE.set(true).expect("DAEMON_MODE already set");
+        run_daemon();
+        return;
     }
 
     tauri::Builder::default()

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -24,7 +24,7 @@ struct Cli {
     daemon: bool,
 
     /// Run the lightweight tray/server mode without the Tauri WebView (~400 MB saved on Linux)
-    #[arg(long)]
+    #[arg(long, conflicts_with = "daemon")]
     mini: bool,
 }
 

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -22,6 +22,10 @@ struct Cli {
     /// Run without GUI — no tray icon or windows, suitable for headless servers
     #[arg(long)]
     daemon: bool,
+
+    /// Run the lightweight tray/server mode without the Tauri WebView (~400 MB saved on Linux)
+    #[arg(long)]
+    mini: bool,
 }
 
 fn main() {
@@ -31,6 +35,7 @@ fn main() {
         verbose: cli.verbose,
         port: cli.port,
         daemon: cli.daemon,
+        mini: cli.mini,
     });
     aw_tauri_lib::run();
 }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -18,6 +18,10 @@ struct Cli {
     /// Override the port number
     #[arg(long)]
     port: Option<u16>,
+
+    /// Run without GUI — no tray icon or windows, suitable for headless servers
+    #[arg(long)]
+    daemon: bool,
 }
 
 fn main() {
@@ -26,6 +30,7 @@ fn main() {
         testing: cli.testing,
         verbose: cli.verbose,
         port: cli.port,
+        daemon: cli.daemon,
     });
     aw_tauri_lib::run();
 }

--- a/src-tauri/src/manager.rs
+++ b/src-tauri/src/manager.rs
@@ -366,6 +366,10 @@ pub fn start_manager() -> Arc<Mutex<ManagerState>> {
     start_manager_inner(get_config().port, None)
 }
 
+pub(crate) fn start_manager_with_port(server_port: u16) -> Arc<Mutex<ManagerState>> {
+    start_manager_inner(server_port, None)
+}
+
 pub(crate) fn start_manager_with_events(
     server_port: u16,
     event_tx: Sender<ManagerEvent>,

--- a/src-tauri/src/manager.rs
+++ b/src-tauri/src/manager.rs
@@ -30,7 +30,7 @@ use {
     },
 };
 
-use log::{debug, error, info, trace};
+use log::{debug, error, info, trace, warn};
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::path::PathBuf;
 use std::process::Command;
@@ -59,11 +59,28 @@ enum ModuleMessage {
         output: std::process::Output,
     },
     Init {},
+    Notification {
+        title: String,
+        message: String,
+    },
+}
+
+#[derive(Debug, Clone)]
+pub(crate) enum ManagerEvent {
+    ModulesChanged {
+        modules_running: BTreeMap<String, bool>,
+        modules_discovered: BTreeMap<String, PathBuf>,
+    },
+    Notification {
+        title: String,
+        message: String,
+    },
 }
 
 #[derive(Debug)]
 pub struct ManagerState {
     tx: Sender<ModuleMessage>,
+    pub server_port: u16,
     pub modules_running: BTreeMap<String, bool>,
     pub modules_discovered: BTreeMap<String, PathBuf>,
     pub modules_pid: HashMap<String, u32>,
@@ -74,9 +91,10 @@ pub struct ManagerState {
 }
 
 impl ManagerState {
-    fn new(tx: Sender<ModuleMessage>) -> ManagerState {
+    fn new(tx: Sender<ModuleMessage>, server_port: u16) -> ManagerState {
         ManagerState {
             tx,
+            server_port,
             //TODO: merge some of these maps into a single struct
             modules_running: BTreeMap::new(),
             modules_discovered: discover_modules(),
@@ -108,6 +126,7 @@ impl ManagerState {
                     name.to_string(),
                     path.clone(),
                     args.cloned(),
+                    self.server_port,
                     self.tx.clone(),
                 );
             } else {
@@ -147,7 +166,16 @@ impl ManagerState {
 fn update_tray_menu(
     modules_running: &BTreeMap<String, bool>,
     modules_discovered: &BTreeMap<String, PathBuf>,
+    event_tx: &Option<Sender<ManagerEvent>>,
 ) {
+    // In mini mode, forward state to the mini event loop instead of Tauri
+    if let Some(tx) = event_tx {
+        let _ = tx.send(ManagerEvent::ModulesChanged {
+            modules_running: modules_running.clone(),
+            modules_discovered: modules_discovered.clone(),
+        });
+        return;
+    }
     if crate::is_daemon_mode() {
         return;
     }
@@ -335,8 +363,22 @@ fn monitor_parent_process(child_pid: u32, read_fd: i32) {
 }
 
 pub fn start_manager() -> Arc<Mutex<ManagerState>> {
+    start_manager_inner(get_config().port, None)
+}
+
+pub(crate) fn start_manager_with_events(
+    server_port: u16,
+    event_tx: Sender<ManagerEvent>,
+) -> Arc<Mutex<ManagerState>> {
+    start_manager_inner(server_port, Some(event_tx))
+}
+
+fn start_manager_inner(
+    server_port: u16,
+    event_tx: Option<Sender<ManagerEvent>>,
+) -> Arc<Mutex<ManagerState>> {
     let (tx, rx) = channel();
-    let state = Arc::new(Mutex::new(ManagerState::new(tx.clone())));
+    let state = Arc::new(Mutex::new(ManagerState::new(tx.clone(), server_port)));
 
     // Start the modules
     let config = get_config();
@@ -368,16 +410,27 @@ pub fn start_manager() -> Arc<Mutex<ManagerState>> {
 
     let state_clone = Arc::clone(&state);
     thread::spawn(move || {
-        handle(rx, state_clone);
+        handle(rx, state_clone, event_tx);
     });
     state
 }
 
-fn handle(rx: Receiver<ModuleMessage>, state: Arc<Mutex<ManagerState>>) {
+fn handle(
+    rx: Receiver<ModuleMessage>,
+    state: Arc<Mutex<ManagerState>>,
+    event_tx: Option<Sender<ManagerEvent>>,
+) {
     loop {
         let msg = rx.recv().expect("Failed to receive Module message");
         let state_clone = Arc::clone(&state);
 
+        // aw-notify notifications are forwarded directly without touching tray state
+        if let ModuleMessage::Notification { title, message } = msg {
+            route_notification(&event_tx, &title, &message);
+            continue;
+        }
+
+        let event_tx_for_restart = event_tx.clone();
         let (modules_running, modules_discovered) = {
             let mut state_guard = state.lock().expect("Failed to acquire manager_state lock");
             match msg {
@@ -435,21 +488,10 @@ fn handle(rx: Receiver<ModuleMessage>, state: Arc<Mutex<ManagerState>>) {
 
                             if should_restart {
                                 if let Some((secs, restart_count)) = restart_info {
-                                    {
-                                        // Show dialog BEFORE sleeping (skip in daemon mode)
-                                        if !crate::is_daemon_mode() {
-                                            let app = &*get_app_handle()
-                                                .lock()
-                                                .expect("Failed to get app handle");
-                                            app.dialog()
-                                                .message(format!(
-                                                    "{name_clone} crashed. Restarting..."
-                                                ))
-                                                .kind(MessageDialogKind::Warning)
-                                                .title("Warning")
-                                                .show(|_| {});
-                                        }
-                                    }
+                                    show_warning(
+                                        &event_tx_for_restart,
+                                        &format!("{name_clone} crashed. Restarting..."),
+                                    );
                                     error!("Module {name_clone} crashed and will be restarted");
 
                                     thread::sleep(Duration::from_secs(secs));
@@ -477,19 +519,12 @@ fn handle(rx: Receiver<ModuleMessage>, state: Arc<Mutex<ManagerState>>) {
                                 state_guard
                                     .modules_pending_shutdown
                                     .insert(name_clone.clone(), true);
-
-                                if !crate::is_daemon_mode() {
-                                    let app = &*get_app_handle()
-                                        .lock()
-                                        .expect("Failed to get app handle");
-                                    app.dialog()
-                                        .message(format!(
-                                            "{name_clone} keeps on crashing. Restart limit reached."
-                                        ))
-                                        .kind(MessageDialogKind::Warning)
-                                        .title("Warning")
-                                        .show(|_| {});
-                                }
+                                show_warning(
+                                    &event_tx_for_restart,
+                                    &format!(
+                                        "{name_clone} keeps on crashing. Restart limit reached."
+                                    ),
+                                );
                                 error!("Module {name_clone} exceeded crash restart limit");
                             }
                         });
@@ -509,9 +544,11 @@ fn handle(rx: Receiver<ModuleMessage>, state: Arc<Mutex<ManagerState>>) {
                     state_guard.modules_running.clone(),
                     state_guard.modules_discovered.clone(),
                 ),
+                // Already handled above via early-continue
+                ModuleMessage::Notification { .. } => unreachable!(),
             }
         };
-        update_tray_menu(&modules_running, &modules_discovered);
+        update_tray_menu(&modules_running, &modules_discovered, &event_tx);
     }
 }
 
@@ -519,22 +556,24 @@ fn start_module_thread(
     name: String,
     path: PathBuf,
     custom_args: Option<Vec<String>>,
+    server_port: u16,
     tx: Sender<ModuleMessage>,
 ) {
     // Special handling for aw-notify module
     if name == "aw-notify" {
         info!("Using special aw-notify handler for module: {name}");
-        start_notify_module_thread(name, path, custom_args, tx);
+        start_notify_module_thread(name, path, custom_args, server_port, tx);
         return;
     }
 
-    start_generic_module_thread(name, path, custom_args, tx);
+    start_generic_module_thread(name, path, custom_args, server_port, tx);
 }
 
 fn start_generic_module_thread(
     name: String,
     path: PathBuf,
     custom_args: Option<Vec<String>>,
+    server_port: u16,
     tx: Sender<ModuleMessage>,
 ) {
     thread::spawn(move || {
@@ -567,8 +606,8 @@ fn start_generic_module_thread(
         // Use custom args if provided, otherwise only pass port arg if it's not the default (5600)
         if let Some(ref args) = custom_args {
             command.args(args);
-        } else if get_config().port != 5600 {
-            command.args(["--port", get_config().port.to_string().as_str()]);
+        } else if server_port != 5600 {
+            command.args(["--port", server_port.to_string().as_str()]);
         }
 
         // Set creation flags on Windows to hide console window
@@ -652,6 +691,7 @@ fn start_notify_module_thread(
     name: String,
     path: PathBuf,
     custom_args: Option<Vec<String>>,
+    server_port: u16,
     tx: Sender<ModuleMessage>,
 ) {
     thread::spawn(move || {
@@ -686,9 +726,9 @@ fn start_notify_module_thread(
         let mut args = vec!["--output-only".to_string()];
 
         // Add port argument if not default (5600)
-        if get_config().port != 5600 {
+        if server_port != 5600 {
             args.push("--port".to_string());
-            args.push(get_config().port.to_string());
+            args.push(server_port.to_string());
         }
 
         // Add any custom args
@@ -724,7 +764,7 @@ fn start_notify_module_thread(
                         let _ = close(pipe_read_fd);
                     }
                     // Fallback to generic module handler to avoid recursion
-                    start_generic_module_thread(name, path, custom_args, tx);
+                    start_generic_module_thread(name, path, custom_args, server_port, tx);
                     return;
                 } else {
                     error!("Failed to start module {name}: {e}");
@@ -790,7 +830,11 @@ fn start_notify_module_thread(
                                 notification.get("title").and_then(|t| t.as_str()),
                                 notification.get("message").and_then(|m| m.as_str()),
                             ) {
-                                send_notification(title, message);
+                                tx.send(ModuleMessage::Notification {
+                                    title: title.to_string(),
+                                    message: message.to_string(),
+                                })
+                                .expect("Failed to send notification message");
                                 info!(
                                     "Parsed JSON notification: title='{}', message length={}",
                                     title,
@@ -833,7 +877,7 @@ fn start_notify_module_thread(
                 }
 
                 // Fallback to generic module handler
-                start_generic_module_thread(name, path, custom_args, tx);
+                start_generic_module_thread(name, path, custom_args, server_port, tx);
                 return;
             }
         }
@@ -855,7 +899,40 @@ fn start_notify_module_thread(
     });
 }
 
-fn send_notification(title: &str, message: &str) {
+/// Route a notification: send via ManagerEvent channel (mini mode) or Tauri (GUI mode).
+fn route_notification(event_tx: &Option<Sender<ManagerEvent>>, title: &str, message: &str) {
+    if let Some(tx) = event_tx {
+        let _ = tx.send(ManagerEvent::Notification {
+            title: title.to_string(),
+            message: message.to_string(),
+        });
+        return;
+    }
+    send_tauri_notification(title, message);
+}
+
+/// Route a warning dialog: send via ManagerEvent channel (mini mode) or Tauri dialog (GUI mode).
+fn show_warning(event_tx: &Option<Sender<ManagerEvent>>, message: &str) {
+    if let Some(tx) = event_tx {
+        let _ = tx.send(ManagerEvent::Notification {
+            title: "Warning".to_string(),
+            message: message.to_string(),
+        });
+        return;
+    }
+    if crate::is_daemon_mode() {
+        warn!("{message}");
+        return;
+    }
+    let app = &*get_app_handle().lock().expect("Failed to get app handle");
+    app.dialog()
+        .message(message)
+        .kind(MessageDialogKind::Warning)
+        .title("Warning")
+        .show(|_| {});
+}
+
+fn send_tauri_notification(title: &str, message: &str) {
     if crate::is_daemon_mode() {
         info!(
             "Notification (suppressed in daemon mode): {} — {}",

--- a/src-tauri/src/manager.rs
+++ b/src-tauri/src/manager.rs
@@ -148,6 +148,9 @@ fn update_tray_menu(
     modules_running: &BTreeMap<String, bool>,
     modules_discovered: &BTreeMap<String, PathBuf>,
 ) {
+    if crate::is_daemon_mode() {
+        return;
+    }
     let (lock, cvar) = &*HANDLE_CONDVAR;
     let mut state = lock.lock().expect("Failed to acquire manager_state lock");
 
@@ -433,15 +436,19 @@ fn handle(rx: Receiver<ModuleMessage>, state: Arc<Mutex<ManagerState>>) {
                             if should_restart {
                                 if let Some((secs, restart_count)) = restart_info {
                                     {
-                                        // Show dialog BEFORE sleeping
-                                        let app = &*get_app_handle()
-                                            .lock()
-                                            .expect("Failed to get app handle");
-                                        app.dialog()
-                                            .message(format!("{name_clone} crashed. Restarting..."))
-                                            .kind(MessageDialogKind::Warning)
-                                            .title("Warning")
-                                            .show(|_| {});
+                                        // Show dialog BEFORE sleeping (skip in daemon mode)
+                                        if !crate::is_daemon_mode() {
+                                            let app = &*get_app_handle()
+                                                .lock()
+                                                .expect("Failed to get app handle");
+                                            app.dialog()
+                                                .message(format!(
+                                                    "{name_clone} crashed. Restarting..."
+                                                ))
+                                                .kind(MessageDialogKind::Warning)
+                                                .title("Warning")
+                                                .show(|_| {});
+                                        }
                                     }
                                     error!("Module {name_clone} crashed and will be restarted");
 
@@ -471,15 +478,18 @@ fn handle(rx: Receiver<ModuleMessage>, state: Arc<Mutex<ManagerState>>) {
                                     .modules_pending_shutdown
                                     .insert(name_clone.clone(), true);
 
-                                let app =
-                                    &*get_app_handle().lock().expect("Failed to get app handle");
-                                app.dialog()
-                                    .message(format!(
-                                        "{name_clone} keeps on crashing. Restart limit reached."
-                                    ))
-                                    .kind(MessageDialogKind::Warning)
-                                    .title("Warning")
-                                    .show(|_| {});
+                                if !crate::is_daemon_mode() {
+                                    let app = &*get_app_handle()
+                                        .lock()
+                                        .expect("Failed to get app handle");
+                                    app.dialog()
+                                        .message(format!(
+                                            "{name_clone} keeps on crashing. Restart limit reached."
+                                        ))
+                                        .kind(MessageDialogKind::Warning)
+                                        .title("Warning")
+                                        .show(|_| {});
+                                }
                                 error!("Module {name_clone} exceeded crash restart limit");
                             }
                         });
@@ -846,6 +856,13 @@ fn start_notify_module_thread(
 }
 
 fn send_notification(title: &str, message: &str) {
+    if crate::is_daemon_mode() {
+        info!(
+            "Notification (suppressed in daemon mode): {} — {}",
+            title, message
+        );
+        return;
+    }
     // Get app handle and send notification
     if let Ok(app_handle_guard) = get_app_handle().lock() {
         let app_handle = &*app_handle_guard;

--- a/src-tauri/src/mini.rs
+++ b/src-tauri/src/mini.rs
@@ -1,0 +1,248 @@
+// Based on wind-mask/aw-tauri@435b3b6c
+// Lightweight mode: tray + server, no Tauri WebView (~400 MB saved on Linux).
+
+use crate::manager;
+use log::{error, info, warn};
+use std::{
+    collections::BTreeMap,
+    io::Cursor,
+    path::{Path, PathBuf},
+    sync::mpsc,
+    thread,
+};
+use tao::{
+    event::{Event, StartCause},
+    event_loop::{ControlFlow, EventLoopBuilder},
+};
+use tray_icon::{
+    menu::{CheckMenuItem, Menu, MenuEvent, MenuItem, PredefinedMenuItem, Submenu},
+    Icon, TrayIcon, TrayIconBuilder,
+};
+
+enum MiniEvent {
+    Menu(MenuEvent),
+    Manager(manager::ManagerEvent),
+}
+
+pub fn run() {
+    let cli_args = crate::get_cli_args();
+
+    let user_config = crate::get_config();
+
+    let (dashboard_url, server_state, aw_config) =
+        match crate::prepare_aw_server(user_config, cli_args) {
+            Ok(server) => server,
+            Err(message) => {
+                error!("{}", message);
+                eprintln!("{}", message);
+                return;
+            }
+        };
+    let server_port = aw_config.port;
+    tauri::async_runtime::spawn(
+        aw_server::endpoints::build_rocket(server_state, aw_config).launch(),
+    );
+    info!("Running aw-tauri mini mode at {}", dashboard_url.as_str());
+
+    let event_loop = EventLoopBuilder::<MiniEvent>::with_user_event().build();
+    let menu_proxy = event_loop.create_proxy();
+    MenuEvent::set_event_handler(Some(move |event| {
+        let _ = menu_proxy.send_event(MiniEvent::Menu(event));
+    }));
+
+    let (manager_tx, manager_rx) = mpsc::channel();
+    let manager_proxy = event_loop.create_proxy();
+    thread::spawn(move || {
+        for event in manager_rx {
+            if manager_proxy.send_event(MiniEvent::Manager(event)).is_err() {
+                break;
+            }
+        }
+    });
+
+    let manager_state = manager::start_manager_with_events(server_port, manager_tx);
+    let (mut modules_running, mut modules_discovered) = {
+        let state = manager_state
+            .lock()
+            .expect("Failed to acquire manager_state lock");
+        (
+            state.modules_running.clone(),
+            state.modules_discovered.clone(),
+        )
+    };
+
+    let mut tray_icon: Option<TrayIcon> = None;
+    let mut first_run_notified = false;
+
+    event_loop.run(move |event, _, control_flow| {
+        *control_flow = ControlFlow::Wait;
+
+        match event {
+            Event::NewEvents(StartCause::Init) if tray_icon.is_none() => {
+                tray_icon = Some(create_tray_icon(&modules_running, &modules_discovered));
+                if !first_run_notified && *crate::is_first_run() {
+                    show_notification(
+                        "Aw-Tauri",
+                        "Welcome to Aw-Tauri! Use the tray icon to open the dashboard.",
+                    );
+                    first_run_notified = true;
+                }
+            }
+            Event::UserEvent(MiniEvent::Menu(event)) => {
+                let id = event.id.0;
+                match id.as_str() {
+                    "open" => open_dashboard(dashboard_url.as_str()),
+                    "quit" => {
+                        if let Ok(mut state) = manager_state.lock() {
+                            state.stop_modules();
+                        }
+                        *control_flow = ControlFlow::Exit;
+                    }
+                    "config_folder" => {
+                        let config_path = crate::get_config_path();
+                        let config_dir = config_path.parent().unwrap_or(&config_path);
+                        open_path(config_dir);
+                    }
+                    "log_folder" => {
+                        let log_path = crate::logging::get_log_path();
+                        let log_dir = log_path.parent().unwrap_or(&log_path);
+                        open_path(log_dir);
+                    }
+                    _ => {
+                        if let Some(module_name) = id.strip_prefix("module:") {
+                            if let Ok(mut state) = manager_state.lock() {
+                                state.handle_system_click(module_name);
+                            }
+                        }
+                    }
+                }
+            }
+            Event::UserEvent(MiniEvent::Manager(event)) => match event {
+                manager::ManagerEvent::ModulesChanged {
+                    modules_running: running,
+                    modules_discovered: discovered,
+                } => {
+                    modules_running = running;
+                    modules_discovered = discovered;
+                    if let Some(tray_icon) = &tray_icon {
+                        update_tray_menu(tray_icon, &modules_running, &modules_discovered);
+                    }
+                }
+                manager::ManagerEvent::Notification { title, message } => {
+                    show_notification(&title, &message);
+                }
+            },
+            _ => {}
+        }
+    });
+}
+
+fn create_tray_icon(
+    modules_running: &BTreeMap<String, bool>,
+    modules_discovered: &BTreeMap<String, PathBuf>,
+) -> TrayIcon {
+    let menu = build_tray_menu(modules_running, modules_discovered)
+        .expect("Failed to create mini tray menu");
+    let icon = load_tray_icon().expect("Failed to load mini tray icon");
+
+    let mut builder = TrayIconBuilder::new()
+        .with_menu(Box::new(menu))
+        .with_icon(icon)
+        .with_tooltip("ActivityWatch")
+        .with_menu_on_left_click(true);
+
+    #[cfg(target_os = "linux")]
+    {
+        builder = builder.with_temp_dir_path(crate::dirs::get_runtime_dir().join("tray-icon"));
+    }
+
+    builder.build().expect("Failed to create mini tray")
+}
+
+fn update_tray_menu(
+    tray_icon: &TrayIcon,
+    modules_running: &BTreeMap<String, bool>,
+    modules_discovered: &BTreeMap<String, PathBuf>,
+) {
+    match build_tray_menu(modules_running, modules_discovered) {
+        Ok(menu) => tray_icon.set_menu(Some(Box::new(menu))),
+        Err(e) => error!("Failed to update mini tray menu: {e}"),
+    }
+}
+
+fn build_tray_menu(
+    modules_running: &BTreeMap<String, bool>,
+    modules_discovered: &BTreeMap<String, PathBuf>,
+) -> Result<Menu, Box<dyn std::error::Error>> {
+    let menu = Menu::new();
+    let open = MenuItem::with_id("open", "Open Dashboard", true, None);
+    menu.append(&open)?;
+    menu.append(&PredefinedMenuItem::separator())?;
+
+    let modules_submenu = Submenu::with_id("modules", "Modules", true);
+    for (module, running) in modules_running {
+        let module_menu =
+            CheckMenuItem::with_id(module_menu_id(module), module, true, *running, None);
+        modules_submenu.append(&module_menu)?;
+    }
+    for module in modules_discovered.keys() {
+        if !modules_running.contains_key(module) {
+            let module_menu = MenuItem::with_id(module_menu_id(module), module, true, None);
+            modules_submenu.append(&module_menu)?;
+        }
+    }
+    menu.append(&modules_submenu)?;
+    menu.append(&PredefinedMenuItem::separator())?;
+
+    let config_folder = MenuItem::with_id("config_folder", "Open config folder", true, None);
+    let log_folder = MenuItem::with_id("log_folder", "Open log folder", true, None);
+    menu.append(&config_folder)?;
+    menu.append(&log_folder)?;
+    menu.append(&PredefinedMenuItem::separator())?;
+
+    let quit = MenuItem::with_id("quit", "Quit ActivityWatch", true, None);
+    menu.append(&quit)?;
+
+    Ok(menu)
+}
+
+fn module_menu_id(module: &str) -> String {
+    format!("module:{module}")
+}
+
+fn load_tray_icon() -> Result<Icon, Box<dyn std::error::Error>> {
+    let icon_bytes = include_bytes!("../icons/32x32.png");
+    let decoder = png::Decoder::new(Cursor::new(icon_bytes));
+    let mut reader = decoder.read_info()?;
+    let mut buffer = vec![0; reader.output_buffer_size()];
+    let info = reader.next_frame(&mut buffer)?;
+    let rgba = buffer[..info.buffer_size()].to_vec();
+
+    if info.color_type != png::ColorType::Rgba || info.bit_depth != png::BitDepth::Eight {
+        return Err("mini tray icon must be an 8-bit RGBA PNG".into());
+    }
+
+    Ok(Icon::from_rgba(rgba, info.width, info.height)?)
+}
+
+fn open_dashboard(url: &str) {
+    if let Err(e) = open::that_detached(url) {
+        warn!("Failed to open dashboard: {e}");
+    }
+}
+
+fn open_path(path: &Path) {
+    if let Err(e) = open::that_detached(path) {
+        warn!("Failed to open path {}: {e}", path.display());
+    }
+}
+
+fn show_notification(title: &str, message: &str) {
+    if let Err(e) = notify_rust::Notification::new()
+        .summary(title)
+        .body(message)
+        .show()
+    {
+        warn!("Failed to show notification: {e}");
+    }
+}

--- a/src-tauri/src/mini.rs
+++ b/src-tauri/src/mini.rs
@@ -137,7 +137,7 @@ pub fn run() {
                 if let Ok(mut state) = manager_state.lock() {
                     state.stop_modules();
                 }
-                *control_flow = ControlFlow::Exit;
+                std::process::exit(1);
             }
             Event::UserEvent(MiniEvent::Manager(event)) => match event {
                 manager::ManagerEvent::ModulesChanged {

--- a/src-tauri/src/mini.rs
+++ b/src-tauri/src/mini.rs
@@ -36,7 +36,7 @@ pub fn run() {
             Err(message) => {
                 error!("{}", message);
                 eprintln!("{}", message);
-                return;
+                std::process::exit(1);
             }
         };
     let server_port = aw_config.port;

--- a/src-tauri/src/mini.rs
+++ b/src-tauri/src/mini.rs
@@ -22,6 +22,7 @@ use tray_icon::{
 enum MiniEvent {
     Menu(MenuEvent),
     Manager(manager::ManagerEvent),
+    ServerFailed(String),
 }
 
 pub fn run() {
@@ -39,12 +40,26 @@ pub fn run() {
             }
         };
     let server_port = aw_config.port;
-    tauri::async_runtime::spawn(
+    let rocket_handle = tauri::async_runtime::spawn(
         aw_server::endpoints::build_rocket(server_state, aw_config).launch(),
     );
     info!("Running aw-tauri mini mode at {}", dashboard_url.as_str());
 
     let event_loop = EventLoopBuilder::<MiniEvent>::with_user_event().build();
+    let server_proxy = event_loop.create_proxy();
+    tauri::async_runtime::spawn(async move {
+        match rocket_handle.await {
+            Ok(Err(e)) => {
+                error!("Server exited with error: {e:?}");
+                let _ = server_proxy.send_event(MiniEvent::ServerFailed(format!("{e:?}")));
+            }
+            Err(join_err) => {
+                error!("Rocket task panicked: {join_err:?}");
+                let _ = server_proxy.send_event(MiniEvent::ServerFailed(format!("{join_err:?}")));
+            }
+            Ok(Ok(_)) => {} // clean shutdown — event loop is likely already exiting
+        }
+    });
     let menu_proxy = event_loop.create_proxy();
     MenuEvent::set_event_handler(Some(move |event| {
         let _ = menu_proxy.send_event(MiniEvent::Menu(event));
@@ -116,6 +131,13 @@ pub fn run() {
                         }
                     }
                 }
+            }
+            Event::UserEvent(MiniEvent::ServerFailed(msg)) => {
+                show_notification("ActivityWatch Error", &format!("Server failed: {msg}"));
+                if let Ok(mut state) = manager_state.lock() {
+                    state.stop_modules();
+                }
+                *control_flow = ControlFlow::Exit;
             }
             Event::UserEvent(MiniEvent::Manager(event)) => match event {
                 manager::ManagerEvent::ModulesChanged {


### PR DESCRIPTION
## Summary

Adds two new CLI flags for leaner deployments:

### `--daemon` — headless server, no GUI or tray

```sh
aw-tauri --daemon          # production port (default 5600)
aw-tauri --daemon --testing  # test port (5666)
```

No tray icon, no WebKit, no AppHandle. Pure aw-server + module manager. Useful for headless servers.

### `--mini` — tray + server, no Tauri WebView (~400 MB saved on Linux)

```sh
aw-tauri --mini            # tray icon + server, no WebView
aw-tauri --mini --testing
aw-tauri --mini --port 5700
```

Based on @wind-mask's implementation in wind-mask/aw-tauri@435b3b6c — credit is due there.

Tray menu: Open Dashboard, Modules submenu (CheckMenuItems showing running state), config/log folder shortcuts, Quit. First-run welcome notification.

---

### What changes (`--daemon`)

- **`--daemon` flag** (clap) — `main.rs` and `CliArgs`
- **`DAEMON_MODE` global + `is_daemon_mode()` helper** — thread-safe via `OnceLock`
- **`run_daemon()`** — port check → `ServerState` → module manager → Rocket `launch()`
- **GUI guards** — `update_tray_menu()`, crash/restart dialogs, `send_notification()`, config parse error dialog all gate on `is_daemon_mode()`

### What changes (`--mini`)

- **`--mini` flag** (clap) — `main.rs` and `CliArgs`
- **`mini.rs`** — standalone tao event loop with tray-icon, notify-rust, and open crates
- **`prepare_aw_server()`** — extracted helper shared by mini and full GUI modes
- **`ManagerEvent` enum + `start_manager_with_events()`** — routes events back to mini event loop without coupling `manager.rs` to Tauri's notification API
- **Explicit `server_port` threading** — module-start helpers receive computed port instead of re-reading `get_config()`
- New deps: `tao`, `tray-icon`, `notify-rust`, `open`, `png`

### What stays the same

Normal GUI launch (no flags) is completely unchanged.

Addresses: #223