### PR TITLE
Fix module discovery on Windows for the Tauri install

### DIFF
--- a/src-tauri/src/dirs.rs
+++ b/src-tauri/src/dirs.rs
@@ -173,14 +173,10 @@ pub fn get_discovery_paths() -> Vec<PathBuf> {
         // Windows: User-specific and system paths
         if let Ok(username) = std::env::var("USERNAME") {
             discovery_paths.push(PathBuf::from(format!(r"C:/Users/{}/aw-modules", username)));
-            // The Windows installer (scripts/package/aw-tauri.iss) installs to
-            // Programs/ActivityWatch-Tauri, so the bundled modules live there.
             discovery_paths.push(PathBuf::from(format!(
                 r"C:/Users/{}/AppData/Local/Programs/ActivityWatch-Tauri",
                 username
             )));
-            // Keep the old path so modules from a classic ActivityWatch install
-            // are still found.
             discovery_paths.push(PathBuf::from(format!(
                 r"C:/Users/{}/AppData/Local/Programs/ActivityWatch",
                 username

--- a/src-tauri/src/dirs.rs
+++ b/src-tauri/src/dirs.rs
@@ -173,6 +173,14 @@ pub fn get_discovery_paths() -> Vec<PathBuf> {
         // Windows: User-specific and system paths
         if let Ok(username) = std::env::var("USERNAME") {
             discovery_paths.push(PathBuf::from(format!(r"C:/Users/{}/aw-modules", username)));
+            // The Windows installer (scripts/package/aw-tauri.iss) installs to
+            // Programs/ActivityWatch-Tauri, so the bundled modules live there.
+            discovery_paths.push(PathBuf::from(format!(
+                r"C:/Users/{}/AppData/Local/Programs/ActivityWatch-Tauri",
+                username
+            )));
+            // Keep the old path so modules from a classic ActivityWatch install
+            // are still found.
             discovery_paths.push(PathBuf::from(format!(
                 r"C:/Users/{}/AppData/Local/Programs/ActivityWatch",
                 username


### PR DESCRIPTION
On Windows the installer (scripts/package/aw-tauri.iss in the activitywatch repo) installs the app into Programs/ActivityWatch-Tauri, and the bundled watcher modules are copied there too.

The module discovery code in dirs.rs only looked in Programs/ActivityWatch, so after a fresh install none of the modules were found and the app crashed on startup. A user in the linked issue traced this down and confirmed that pointing the discovery path at ActivityWatch-Tauri fixes it.

This change adds the ActivityWatch-Tauri path to the Windows discovery list. I left the old ActivityWatch path in place so that modules from a classic ActivityWatch install are still picked up.

Fixes ActivityWatch/activitywatch#1359