### PR TITLE
fix(ci): avoid secrets in step conditions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,6 +21,8 @@ jobs:
           - platform: 'windows-11-arm' # for Windows ARM64
             args: '--target aarch64-pc-windows-msvc --bundles msi'
     runs-on: ${{ matrix.platform }}
+    env:
+      HAS_TAURI_SIGNING_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY != '' }}
 
     steps:
       - name: Checkout repository
@@ -85,7 +87,7 @@ jobs:
           Write-Host "WiX installed to $wixDir ($(Get-ChildItem $wixDir | Measure-Object | Select-Object -Expand Count) files)"
 
       - name: Configure updater artifacts
-        if: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY != '' }}
+        if: env.HAS_TAURI_SIGNING_KEY == 'true'
         shell: bash
         run: |
           python3 - <<'PY'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,8 @@ jobs:
           - platform: 'windows-11-arm' # for Windows ARM64
             args: '--target aarch64-pc-windows-msvc'
     runs-on: ${{ matrix.platform }}
+    env:
+      HAS_TAURI_SIGNING_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY != '' }}
 
     steps:
       - name: Checkout repository
@@ -81,7 +83,7 @@ jobs:
         run: rustup target add $(echo "${{ matrix.args }}" | cut -d' ' -f2)
 
       - name: Configure updater artifacts
-        if: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY != '' }}
+        if: env.HAS_TAURI_SIGNING_KEY == 'true'
         shell: bash
         run: |
           python3 - <<'PY'
@@ -106,5 +108,5 @@ jobs:
           releaseBody: 'See the assets to download and install this version.'
           releaseDraft: true
           prerelease: false
-          includeUpdaterJson: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY != '' }}
+          includeUpdaterJson: ${{ env.HAS_TAURI_SIGNING_KEY }}
           args: ${{ matrix.args }}


### PR DESCRIPTION
## Summary
- move the signing-key presence check to job-level `env`, where the `secrets` context is valid
- gate updater artifact configuration through that derived environment value
- pass the same derived value to `includeUpdaterJson` in the release workflow

## Root cause

ActivityWatch/aw-tauri#235 introduced `secrets.TAURI_SIGNING_PRIVATE_KEY` directly in step-level `if:` expressions. GitHub rejects that context while parsing a workflow, so both Build and Release failed immediately with zero jobs and no logs on `master`.

## Verification
- `actionlint -shellcheck='' .github/workflows/build.yml .github/workflows/release.yml`
- `git diff --check`
