### PR TITLE
feat(updater): add updater signing pubkey, build updater artifacts when key present

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,8 +5,16 @@ else
 endif
 OS := $(shell uname -s)
 
+# Updater artifacts (.tar.gz/.zip + .sig) require the signing key, so only
+# enable them when TAURI_SIGNING_PRIVATE_KEY is set (release CI). Without it,
+# plain bundles are built and local/fork-PR builds keep working.
+TAURI_BUILD_ARGS :=
+ifdef TAURI_SIGNING_PRIVATE_KEY
+TAURI_BUILD_ARGS += --config '{"bundle":{"createUpdaterArtifacts":true}}'
+endif
+
 build: prebuild
-	npm run tauri build
+	npm run tauri build -- $(TAURI_BUILD_ARGS)
 
 dev: prebuild
 	npm run tauri dev

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -22,7 +22,7 @@
   },
   "plugins": {
     "updater": {
-      "pubkey": "",
+      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IERDOEZGQzlEN0NERDlGQjAKUldTd245MThuZnlQM0Q1Z0JuT0RZU0JEVUxlT0x5TGc0Q09YbVZadHFwRllsRDFRMFJ2eTFtUEYK",
       "endpoints": [
         "https://github.com/ActivityWatch/activitywatch/releases/latest/download/latest.json"
       ],


### PR DESCRIPTION
Part of the updater-prerequisite work for ActivityWatch/activitywatch#1372 (see [prerequisites](https://github.com/ActivityWatch/activitywatch/pull/1372) in that PR's description) and #68.

## Changes

- **Set `plugins.updater.pubkey`** to the new ActivityWatch updater signing public key. The matching private key + password are now configured as `TAURI_SIGNING_PRIVATE_KEY` / `TAURI_SIGNING_PRIVATE_KEY_PASSWORD` Actions secrets on ActivityWatch/activitywatch (where release builds run), and the key material is backed up offline.
- **Enable `bundle.createUpdaterArtifacts` conditionally** via `--config` in the Makefile, only when `TAURI_SIGNING_PRIVATE_KEY` is set. Committing `createUpdaterArtifacts: true` directly would make every `tauri build` fail without the signing key, breaking local builds and fork PRs (no secrets). With this approach, release CI (which has the secret) emits updater bundles + `.sig` files, while everything else builds plain bundles as before.

## Notes

- The endpoint stays as-is (standard edition `latest.json`). The research-edition endpoint split from ActivityWatch/activitywatch#1372 still needs its own handling here — deferring that to @0xbrayo's release-line design.
- Pubkey is a minisign public key generated with tauri-cli 2.11.0; safe to commit (public by design).