### PR TITLE
build(deps): group aw-server-rust updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,14 @@ updates:
     directory: "/src-tauri"
     schedule:
       interval: "weekly"
+    groups:
+      # Both crates come from the same aw-server-rust Git revision. Updating
+      # them separately creates duplicate Cargo.lock PRs and can leave the
+      # update stream blocked behind one stale PR.
+      aw-server-rust:
+        patterns:
+          - "aw-server"
+          - "aw-datastore"
 
   # Enable version updates for GitHub Actions
   - package-ecosystem: "github-actions"


### PR DESCRIPTION
## Summary
- group the `aw-server` and `aw-datastore` Cargo dependency updates
- keep their shared `aw-server-rust` Git revision in one lockfile PR
- prevent duplicate stale PRs from blocking future server updates

## Validation
- parsed `.github/dependabot.yml` with PyYAML
- `git diff --check`