### PR TITLE
fix(deps): update aw-server profile API

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -368,7 +368,7 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 [[package]]
 name = "aw-client-rust"
 version = "0.1.0"
-source = "git+https://github.com/ActivityWatch/aw-server-rust.git?branch=master#840d11c9cb97b1485a60fe77fdbca6537b508eda"
+source = "git+https://github.com/ActivityWatch/aw-server-rust.git?branch=master#c8533a0019ea86312b9dffc8a0dd3ae8483abae2"
 dependencies = [
  "aw-models",
  "chrono",
@@ -388,7 +388,7 @@ dependencies = [
 [[package]]
 name = "aw-datastore"
 version = "0.1.0"
-source = "git+https://github.com/ActivityWatch/aw-server-rust.git?branch=master#840d11c9cb97b1485a60fe77fdbca6537b508eda"
+source = "git+https://github.com/ActivityWatch/aw-server-rust.git?branch=master#c8533a0019ea86312b9dffc8a0dd3ae8483abae2"
 dependencies = [
  "aw-models",
  "aw-transform",
@@ -405,7 +405,7 @@ dependencies = [
 [[package]]
 name = "aw-models"
 version = "0.1.0"
-source = "git+https://github.com/ActivityWatch/aw-server-rust.git?branch=master#840d11c9cb97b1485a60fe77fdbca6537b508eda"
+source = "git+https://github.com/ActivityWatch/aw-server-rust.git?branch=master#c8533a0019ea86312b9dffc8a0dd3ae8483abae2"
 dependencies = [
  "chrono",
  "log",
@@ -417,7 +417,7 @@ dependencies = [
 [[package]]
 name = "aw-query"
 version = "0.1.0"
-source = "git+https://github.com/ActivityWatch/aw-server-rust.git?branch=master#840d11c9cb97b1485a60fe77fdbca6537b508eda"
+source = "git+https://github.com/ActivityWatch/aw-server-rust.git?branch=master#c8533a0019ea86312b9dffc8a0dd3ae8483abae2"
 dependencies = [
  "aw-datastore",
  "aw-models",
@@ -433,7 +433,7 @@ dependencies = [
 [[package]]
 name = "aw-server"
 version = "0.14.0"
-source = "git+https://github.com/ActivityWatch/aw-server-rust.git?branch=master#840d11c9cb97b1485a60fe77fdbca6537b508eda"
+source = "git+https://github.com/ActivityWatch/aw-server-rust.git?branch=master#c8533a0019ea86312b9dffc8a0dd3ae8483abae2"
 dependencies = [
  "android_logger",
  "aw-client-rust",
@@ -509,7 +509,7 @@ dependencies = [
 [[package]]
 name = "aw-transform"
 version = "0.1.0"
-source = "git+https://github.com/ActivityWatch/aw-server-rust.git?branch=master#840d11c9cb97b1485a60fe77fdbca6537b508eda"
+source = "git+https://github.com/ActivityWatch/aw-server-rust.git?branch=master#c8533a0019ea86312b9dffc8a0dd3ae8483abae2"
 dependencies = [
  "aw-models",
  "chrono",
@@ -872,7 +872,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -3486,7 +3486,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -4991,7 +4991,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b1fdf65dd6331831494dd616b30351c38e96e45921a27745cf98490458b90bb"
 dependencies = [
- "dirs 6.0.0",
+ "dirs 4.0.0",
 ]
 
 [[package]]
@@ -5745,7 +5745,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0136791f7c95b1f6dd99f9cc786b91bb81c3800b639b3478e561ddb7be95e5f1"
 dependencies = [
  "fastrand",
- "getrandom 0.4.1",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -6690,7 +6690,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -583,10 +583,10 @@ fn run_daemon() {
         std::process::exit(1);
     }
 
-    let mut aw_config = aw_server::config::create_config(testing, None);
+    let mut aw_config = aw_server::config::create_config(&cli_args.profile, None);
     aw_config.port = port;
 
-    let db_path = match aw_server::dirs::db_path(testing) {
+    let db_path = match aw_server::dirs::db_path(&cli_args.profile) {
         Ok(path) => match path.to_str() {
             Some(s) => s.to_string(),
             None => {
@@ -680,7 +680,7 @@ pub(crate) fn prepare_aw_server(
     let testing = cli_args.testing;
     let legacy_import = false;
 
-    let mut aw_config = aw_server::config::create_config(testing, None);
+    let mut aw_config = aw_server::config::create_config(&cli_args.profile, None);
 
     // Port priority: CLI flag > testing default (5666) > config file
     let port = cli_args
@@ -694,7 +694,7 @@ pub(crate) fn prepare_aw_server(
         return Err(format!("Port {} is already in use", port));
     }
 
-    let db_path = aw_server::dirs::db_path(testing)
+    let db_path = aw_server::dirs::db_path(&cli_args.profile)
         .map_err(|_| "Failed to get db path".to_string())?
         .to_str()
         .ok_or_else(|| "Database path is not valid UTF-8".to_string())?
@@ -980,14 +980,15 @@ pub fn run() {
                 let testing = cli_args.testing;
                 let legacy_import = false;
 
-                let mut aw_config = aw_server::config::create_config(testing, None);
+                let mut aw_config =
+                    aw_server::config::create_config(&cli_args.profile, None);
 
                 // Port priority: CLI flag > testing default (5666) > config file
                 let port = cli_args
                     .port
                     .unwrap_or(if testing { 5666 } else { user_config.port });
                 aw_config.port = port;
-                let db_path = aw_server::dirs::db_path(testing)
+                let db_path = aw_server::dirs::db_path(&cli_args.profile)
                     .expect("Failed to get db path")
                     .to_str()
                     .unwrap()


### PR DESCRIPTION
## Summary
- update the grouped `aw-server-rust` lock revision from `840d11c` to `c8533a0`
- pass the resolved profile name to the updated `aw-server` config and database path APIs
- supersede the lock-only Dependabot update in #245, which correctly exposed the required source adaptation

## Validation
- full `make prebuild`
- `cargo check --locked`
- `cargo test --locked profile::tests` (3 passed)
- `cargo +nightly fmt -- --check`
- `git diff --check`