### PR TITLE
build(deps): bump embedded aw-server-rust to d2e7b80

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -368,7 +368,7 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 [[package]]
 name = "aw-client-rust"
 version = "0.1.0"
-source = "git+https://github.com/ActivityWatch/aw-server-rust.git?branch=master#c8533a0019ea86312b9dffc8a0dd3ae8483abae2"
+source = "git+https://github.com/ActivityWatch/aw-server-rust.git?branch=master#d2e7b803d6d788e461c38da45ce19feaca9513ff"
 dependencies = [
  "aw-models",
  "chrono",
@@ -388,7 +388,7 @@ dependencies = [
 [[package]]
 name = "aw-datastore"
 version = "0.1.0"
-source = "git+https://github.com/ActivityWatch/aw-server-rust.git?branch=master#c8533a0019ea86312b9dffc8a0dd3ae8483abae2"
+source = "git+https://github.com/ActivityWatch/aw-server-rust.git?branch=master#d2e7b803d6d788e461c38da45ce19feaca9513ff"
 dependencies = [
  "aw-models",
  "aw-transform",
@@ -405,7 +405,7 @@ dependencies = [
 [[package]]
 name = "aw-models"
 version = "0.1.0"
-source = "git+https://github.com/ActivityWatch/aw-server-rust.git?branch=master#c8533a0019ea86312b9dffc8a0dd3ae8483abae2"
+source = "git+https://github.com/ActivityWatch/aw-server-rust.git?branch=master#d2e7b803d6d788e461c38da45ce19feaca9513ff"
 dependencies = [
  "chrono",
  "log",
@@ -417,7 +417,7 @@ dependencies = [
 [[package]]
 name = "aw-query"
 version = "0.1.0"
-source = "git+https://github.com/ActivityWatch/aw-server-rust.git?branch=master#c8533a0019ea86312b9dffc8a0dd3ae8483abae2"
+source = "git+https://github.com/ActivityWatch/aw-server-rust.git?branch=master#d2e7b803d6d788e461c38da45ce19feaca9513ff"
 dependencies = [
  "aw-datastore",
  "aw-models",
@@ -433,7 +433,7 @@ dependencies = [
 [[package]]
 name = "aw-server"
 version = "0.14.0"
-source = "git+https://github.com/ActivityWatch/aw-server-rust.git?branch=master#c8533a0019ea86312b9dffc8a0dd3ae8483abae2"
+source = "git+https://github.com/ActivityWatch/aw-server-rust.git?branch=master#d2e7b803d6d788e461c38da45ce19feaca9513ff"
 dependencies = [
  "android_logger",
  "aw-client-rust",
@@ -509,7 +509,7 @@ dependencies = [
 [[package]]
 name = "aw-transform"
 version = "0.1.0"
-source = "git+https://github.com/ActivityWatch/aw-server-rust.git?branch=master#c8533a0019ea86312b9dffc8a0dd3ae8483abae2"
+source = "git+https://github.com/ActivityWatch/aw-server-rust.git?branch=master#d2e7b803d6d788e461c38da45ce19feaca9513ff"
 dependencies = [
  "aw-models",
  "chrono",


### PR DESCRIPTION
Advances the six git-locked `aw-server-rust` packages in `src-tauri/Cargo.lock` from `c8533a0` to `d2e7b80` (current aw-server-rust master).

What that range carries:

- ActivityWatch/aw-server-rust#668 — aw-webui `3cbe349` → `13a9428`: Research Edition header badge (aw-webui#941), shipped preset category set (aw-webui#936), server-info TypeError guard (aw-webui#933)
- ActivityWatch/aw-server-rust#663 — optional `priority` field for category rules

No `Cargo.toml` changed between the two revisions — the diff is `.rs` sources plus the `aw-webui` submodule — so the dependency graph is unchanged and this is a pure source-revision update.

### Why now

ActivityWatch/activitywatch#1428 bumps the superproject's `aw-server-rust` submodule to `d2e7b80` so `v0.14.0b5-research` ships those web-UI fixes. `release.yml` runs `scripts/check_tauri_server.py`, which fails the build unless the Tauri `Cargo.lock` revision matches that submodule pin — the guard added after v0.14.0b4 Tauri shipped aw-server-rust 0.13.1. Without this PR, all five Tauri build jobs on #1428 fail at that step.