### PR TITLE
feat(autostart): isolate named profile entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,8 @@ single-instance lock under a sibling appname (`activitywatch-research` instead
 of `activitywatch`). `default` and `testing` keep the paths above so existing
 installs are not orphaned. `--testing` is an alias for `--profile testing`.
 Spawned modules inherit `AW_PROFILE`. Custom profiles take `port` from their
-own config (or `--port`); two instances cannot share 5600.
+own config (or `--port`); two instances cannot share 5600. Enabling **Start at
+login** registers a distinct entry that relaunches the same named profile.
 
 A default config is generated on first run. Example:
 

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -504,6 +504,7 @@ dependencies = [
  "toml 1.0.6+spec-1.1.0",
  "tray-icon",
  "winapi",
+ "winreg 0.10.1",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -59,6 +59,7 @@ nix = { version = "0.29.0", features = ["process", "signal"] }
 libc = "0.2"
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3.9", features = ["winuser", "jobapi2", "handleapi", "processthreadsapi", "winnt", "winbase"] }
+winreg = "0.10"
 
 [target.'cfg(not(any(target_os = "android", target_os = "ios")))'.dependencies]
 tauri-plugin-autostart = "2.2.0"

--- a/src-tauri/src/autostart.rs
+++ b/src-tauri/src/autostart.rs
@@ -6,6 +6,7 @@
 //! which applies the OS change, verifies it took effect, persists it, and rolls
 //! the OS change back if persisting fails.
 
+use std::fs;
 use std::path::Path;
 use std::sync::Mutex;
 
@@ -14,6 +15,7 @@ use tauri::menu::CheckMenuItem;
 use tauri::{AppHandle, Wry};
 use tauri_plugin_autostart::ManagerExt;
 
+use crate::profile;
 use crate::{get_config, get_config_path, write_formatted_config, UserConfig};
 
 /// Menu id of the tray "Start at login" item.
@@ -87,6 +89,8 @@ pub fn set_enabled(app: &AppHandle, enabled: bool) -> Result<bool, String> {
 /// file take effect — and it is applied in *both* directions, so clearing the
 /// flag also removes an already-registered login item.
 pub fn sync_from_config(app: &AppHandle) {
+    migrate_legacy_named_profile_entry(&profile::current_profile());
+
     let desired = get_config().autostart.enabled;
     let current = match is_registered(app) {
         Ok(current) => current,
@@ -111,6 +115,98 @@ pub fn sync_from_config(app: &AppHandle) {
         Ok(()) => info!("Registered for autostart: {desired}"),
         // A missing/read-only autostart directory shouldn't stop the app from starting.
         Err(e) => warn!("Failed to set autostart to {desired}: {e}"),
+    }
+}
+
+/// Drop a leftover shared `aw-tauri` login entry if a previous release
+/// registered this named profile under that identity. The default profile
+/// still owns that name, so we only remove the entry when its command
+/// contains `--profile <this>`.
+fn migrate_legacy_named_profile_entry(profile: &str) {
+    if profile::is_default(profile) {
+        return;
+    }
+
+    #[cfg(target_os = "linux")]
+    if let Some(path) = legacy_linux_desktop_path() {
+        remove_legacy_file_if_owned(&path, profile);
+    }
+
+    #[cfg(target_os = "macos")]
+    if let Some(path) = legacy_macos_launch_agent_path() {
+        remove_legacy_file_if_owned(&path, profile);
+    }
+
+    #[cfg(windows)]
+    migrate_legacy_windows_run_value(profile);
+}
+
+#[cfg(target_os = "linux")]
+fn legacy_linux_desktop_path() -> Option<std::path::PathBuf> {
+    dirs::home_dir().map(|home| {
+        home.join(".config/autostart")
+            .join(format!("{}.desktop", profile::LEGACY_AUTOSTART_APP_NAME))
+    })
+}
+
+#[cfg(target_os = "macos")]
+fn legacy_macos_launch_agent_path() -> Option<std::path::PathBuf> {
+    dirs::home_dir().map(|home| {
+        home.join("Library/LaunchAgents")
+            .join(format!("{}.plist", profile::LEGACY_AUTOSTART_APP_NAME))
+    })
+}
+
+fn remove_legacy_file_if_owned(path: &Path, profile: &str) -> bool {
+    let Ok(contents) = fs::read_to_string(path) else {
+        return false;
+    };
+    if !profile::command_targets_profile(&contents, profile) {
+        return false;
+    }
+    match fs::remove_file(path) {
+        Ok(()) => {
+            info!(
+                "Removed leftover autostart entry at {} owned by profile {profile}",
+                path.display()
+            );
+            true
+        }
+        Err(e) => {
+            warn!(
+                "Failed to remove leftover autostart entry {}: {e}",
+                path.display()
+            );
+            false
+        }
+    }
+}
+
+#[cfg(windows)]
+fn migrate_legacy_windows_run_value(profile: &str) {
+    use winreg::enums::{HKEY_CURRENT_USER, KEY_READ, KEY_SET_VALUE};
+    use winreg::RegKey;
+
+    const RUN_KEY: &str = r"SOFTWARE\Microsoft\Windows\CurrentVersion\Run";
+    let hkcu = RegKey::predef(HKEY_CURRENT_USER);
+    let Ok(key) = hkcu.open_subkey_with_flags(RUN_KEY, KEY_READ) else {
+        return;
+    };
+    let Ok(value) = key.get_value::<String, _>(profile::LEGACY_AUTOSTART_APP_NAME) else {
+        return;
+    };
+    if !profile::command_targets_profile(&value, profile) {
+        return;
+    }
+    match hkcu.open_subkey_with_flags(RUN_KEY, KEY_SET_VALUE) {
+        Ok(key) => match key.delete_value(profile::LEGACY_AUTOSTART_APP_NAME) {
+            Ok(()) => info!(
+                "Removed leftover Windows Run value {} owned by profile {profile}",
+                profile::LEGACY_AUTOSTART_APP_NAME
+            ),
+            Err(e) => warn!("Failed to remove leftover Windows Run value: {e}"),
+        },
+        Err(e) => warn!("Failed to open Windows Run key for leftover removal: {e}"),
     }
 }
 
@@ -322,7 +418,8 @@ fn is_dotted_autostart_enabled(trimmed: &str) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use super::patch_autostart_enabled;
+    use super::{patch_autostart_enabled, remove_legacy_file_if_owned};
+    use std::fs;
 
     const CONFIG: &str = r#"port = 5600
 discovery_paths = []
@@ -407,5 +504,49 @@ auto_download = true
         let patched =
             patch_autostart_enabled("[autostart]\r\nenabled = true\r\n", false).expect("patch");
         assert_eq!(patched, "[autostart]\r\nenabled = false\r\n");
+    }
+
+    fn write_temp_entry(name: &str, contents: &str) -> std::path::PathBuf {
+        let path = std::env::temp_dir().join(format!(
+            "aw-tauri-legacy-autostart-{}-{}-{name}.desktop",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        fs::write(&path, contents).expect("write temp autostart entry");
+        path
+    }
+
+    #[test]
+    fn migrate_removes_legacy_entry_owned_by_this_profile() {
+        let path = write_temp_entry(
+            "owned",
+            "Exec=/usr/bin/aw-tauri --profile research\nName=aw-tauri\n",
+        );
+        assert!(remove_legacy_file_if_owned(&path, "research"));
+        assert!(!path.exists(), "owned leftover should be deleted");
+    }
+
+    #[test]
+    fn migrate_keeps_legacy_entry_owned_by_default_or_other_profile() {
+        let default_path = write_temp_entry("default", "Exec=/usr/bin/aw-tauri\nName=aw-tauri\n");
+        let other_path = write_temp_entry(
+            "other",
+            "Exec=/usr/bin/aw-tauri --profile testing\nName=aw-tauri\n",
+        );
+        assert!(!remove_legacy_file_if_owned(&default_path, "research"));
+        assert!(!remove_legacy_file_if_owned(&other_path, "research"));
+        assert!(
+            default_path.exists(),
+            "default identity must be left intact"
+        );
+        assert!(
+            other_path.exists(),
+            "other named leftover must be left intact"
+        );
+        let _ = fs::remove_file(&default_path);
+        let _ = fs::remove_file(&other_path);
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -13,6 +13,7 @@ use std::path::{Path, PathBuf};
 use std::sync::{mpsc, Condvar, Mutex, OnceLock};
 use std::thread;
 use std::time::Duration;
+#[cfg(target_os = "macos")]
 use tauri_plugin_autostart::MacosLauncher;
 use tauri_plugin_dialog::{DialogExt, MessageDialogButtons, MessageDialogKind};
 use tauri_plugin_notification::NotificationExt;
@@ -935,20 +936,24 @@ pub fn run() {
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_notification::init())
         .plugin(tauri_plugin_dialog::init())
-        .plugin(tauri_plugin_autostart::init(
+        .plugin({
             // AppleScript login items silently drop extra arguments; LaunchAgent
             // writes a plist with ProgramArguments so --profile survives relogin.
-            if profile::is_default(&cli_args.profile) {
-                MacosLauncher::AppleScript
-            } else {
-                MacosLauncher::LaunchAgent
-            },
-            if profile::is_default(&cli_args.profile) {
-                Some(vec![])
-            } else {
-                Some(vec!["--profile", cli_args.profile.as_str()])
-            },
-        ))
+            let mut builder = tauri_plugin_autostart::Builder::new()
+                .app_name(profile::autostart_app_name(&cli_args.profile));
+            if !profile::is_default(&cli_args.profile) {
+                builder = builder.args(["--profile", cli_args.profile.as_str()]);
+            }
+            #[cfg(target_os = "macos")]
+            {
+                builder = builder.macos_launcher(if profile::is_default(&cli_args.profile) {
+                    MacosLauncher::AppleScript
+                } else {
+                    MacosLauncher::LaunchAgent
+                });
+            }
+            builder.build()
+        })
         .plugin(single_instance_plugin(&cli_args.profile))
         // Serve the module-alert HTML with a valid Origin for the webview.
         .register_uri_scheme_protocol(module_alert_ui::URI_SCHEME, |_ctx, _request| {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -939,10 +939,11 @@ pub fn run() {
         .plugin({
             // AppleScript login items silently drop extra arguments; LaunchAgent
             // writes a plist with ProgramArguments so --profile survives relogin.
-            let mut builder = tauri_plugin_autostart::Builder::new()
-                .app_name(profile::autostart_app_name(&cli_args.profile));
-            if !profile::is_default(&cli_args.profile) {
-                builder = builder.args(["--profile", cli_args.profile.as_str()]);
+            let mut builder = tauri_plugin_autostart::Builder::new();
+            if let Some(app_name) = profile::autostart_app_name(&cli_args.profile) {
+                builder = builder
+                    .app_name(app_name)
+                    .args(["--profile", cli_args.profile.as_str()]);
             }
             #[cfg(target_os = "macos")]
             {

--- a/src-tauri/src/profile.rs
+++ b/src-tauri/src/profile.rs
@@ -132,13 +132,14 @@ pub fn window_title(profile: &str) -> String {
     }
 }
 
-/// OS autostart entry name. Named profiles need distinct identities so one
-/// profile's tray toggle cannot overwrite or disable another profile's entry.
-pub fn autostart_app_name(profile: &str) -> String {
+/// OS autostart entry name. The default profile keeps the plugin's legacy
+/// package-name identity; named profiles use distinct identities so one tray
+/// toggle cannot overwrite or disable another profile's entry.
+pub fn autostart_app_name(profile: &str) -> Option<String> {
     if is_default(profile) {
-        "ActivityWatch".to_string()
+        None
     } else {
-        format!("ActivityWatch ({profile})")
+        Some(format!("aw-tauri-{profile}"))
     }
 }
 
@@ -235,8 +236,11 @@ mod tests {
         assert_eq!(tray_tooltip("research"), "ActivityWatch (research)");
         assert_eq!(window_title(DEFAULT_PROFILE), "aw-tauri");
         assert_eq!(window_title("research"), "aw-tauri (research)");
-        assert_eq!(autostart_app_name(DEFAULT_PROFILE), "ActivityWatch");
-        assert_eq!(autostart_app_name("research"), "ActivityWatch (research)");
+        assert_eq!(autostart_app_name(DEFAULT_PROFILE), None);
+        assert_eq!(
+            autostart_app_name("research"),
+            Some("aw-tauri-research".to_string())
+        );
         assert_eq!(
             single_instance_dbus_id(DEFAULT_PROFILE),
             "net.activitywatch.app"

--- a/src-tauri/src/profile.rs
+++ b/src-tauri/src/profile.rs
@@ -132,6 +132,16 @@ pub fn window_title(profile: &str) -> String {
     }
 }
 
+/// OS autostart entry name. Named profiles need distinct identities so one
+/// profile's tray toggle cannot overwrite or disable another profile's entry.
+pub fn autostart_app_name(profile: &str) -> String {
+    if is_default(profile) {
+        "ActivityWatch".to_string()
+    } else {
+        format!("ActivityWatch ({profile})")
+    }
+}
+
 /// Linux D-Bus well-known name base for the single-instance plugin.
 /// `default` uses the bundle identifier; other profiles get a suffix so they
 /// can run at the same time as the default instance.
@@ -225,6 +235,8 @@ mod tests {
         assert_eq!(tray_tooltip("research"), "ActivityWatch (research)");
         assert_eq!(window_title(DEFAULT_PROFILE), "aw-tauri");
         assert_eq!(window_title("research"), "aw-tauri (research)");
+        assert_eq!(autostart_app_name(DEFAULT_PROFILE), "ActivityWatch");
+        assert_eq!(autostart_app_name("research"), "ActivityWatch (research)");
         assert_eq!(
             single_instance_dbus_id(DEFAULT_PROFILE),
             "net.activitywatch.app"

--- a/src-tauri/src/profile.rs
+++ b/src-tauri/src/profile.rs
@@ -132,6 +132,11 @@ pub fn window_title(profile: &str) -> String {
     }
 }
 
+/// Package-name identity used by every autostart entry before profile-aware
+/// names. The default profile keeps this so upgrades do not orphan the
+/// existing login item.
+pub const LEGACY_AUTOSTART_APP_NAME: &str = "aw-tauri";
+
 /// OS autostart entry name. The default profile keeps the plugin's legacy
 /// package-name identity; named profiles use distinct identities so one tray
 /// toggle cannot overwrite or disable another profile's entry.
@@ -139,8 +144,24 @@ pub fn autostart_app_name(profile: &str) -> Option<String> {
     if is_default(profile) {
         None
     } else {
-        Some(format!("aw-tauri-{profile}"))
+        Some(format!("{LEGACY_AUTOSTART_APP_NAME}-{profile}"))
     }
+}
+
+/// True when `command` is the login command of this named profile
+/// (`--profile NAME` as adjacent tokens, including LaunchAgent plist XML).
+/// Default-profile commands have no `--profile` flag, so they never match.
+pub fn command_targets_profile(command: &str, profile: &str) -> bool {
+    if is_default(profile) || profile.is_empty() {
+        return false;
+    }
+    let tokens: Vec<&str> = command
+        .split(|c: char| c.is_whitespace() || matches!(c, '<' | '>' | '"' | '\''))
+        .filter(|t| !t.is_empty() && *t != "string" && *t != "/string")
+        .collect();
+    tokens
+        .windows(2)
+        .any(|pair| pair[0] == "--profile" && pair[1] == profile)
 }
 
 /// Linux D-Bus well-known name base for the single-instance plugin.
@@ -249,5 +270,30 @@ mod tests {
             single_instance_dbus_id("research"),
             "net.activitywatch.app.research"
         );
+    }
+
+    #[test]
+    fn test_command_targets_profile() {
+        assert!(command_targets_profile(
+            "/usr/bin/aw-tauri --profile research",
+            "research"
+        ));
+        assert!(!command_targets_profile(
+            "/usr/bin/aw-tauri --profile research",
+            "testing"
+        ));
+        assert!(!command_targets_profile("/usr/bin/aw-tauri", "research"));
+        assert!(!command_targets_profile(
+            "/usr/bin/aw-tauri --profile research",
+            DEFAULT_PROFILE
+        ));
+        assert!(command_targets_profile(
+            "<string>/Applications/aw-tauri.app</string><string>--profile</string><string>research</string>",
+            "research"
+        ));
+        assert!(!command_targets_profile(
+            r#"C:\Program Files\aw-tauri.exe --profile research-lab"#,
+            "research"
+        ));
     }
 }


### PR DESCRIPTION
## Summary
- give each named profile a distinct OS autostart entry identity
- preserve `--profile NAME` in the login command
- use LaunchAgent on macOS for named profiles because AppleScript login items drop arguments
- keep the default profile's existing autostart behavior unchanged
- document profile-aware **Start at login** behavior

## Verification
- `cargo test profile::tests --locked` (3 passed)
- `cargo check --locked`
- `cargo fmt --check`
- `cargo clippy --locked -- -D warnings`
- production-config local AI review: 5/5 consensus (3/3), no findings, head `473e9683bba4227b260b1bb8199d04b574c76818`
