### PR TITLE
build(deps): combine dependabot updates in /src-tauri

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -808,9 +808,9 @@ dependencies = [
 
 [[package]]
 name = "chrono"
-version = "0.4.43"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fac4744fb15ae8337dc853fee7fb3f4e48c0fbaa23d0afe49c447b4fab126118"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
 dependencies = [
  "iana-time-zone",
  "js-sys",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3426,14 +3426,13 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "open"
-version = "5.3.3"
+version = "5.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43bb73a7fa3799b198970490a51174027ba0d4ec504b03cd08caf513d40024bc"
+checksum = "7c603ab8300cf18bc3b14146b19fe3dfcc4843ae5a400cd0e7a30b95aa366634"
 dependencies = [
  "dunce",
  "is-wsl",
  "libc",
- "pathdiff",
 ]
 
 [[package]]
@@ -3557,12 +3556,6 @@ dependencies = [
  "smallvec",
  "windows-link 0.2.1",
 ]
-
-[[package]]
-name = "pathdiff"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
 
 [[package]]
 name = "pear"

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -368,7 +368,7 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 [[package]]
 name = "aw-client-rust"
 version = "0.1.0"
-source = "git+https://github.com/ActivityWatch/aw-server-rust.git?branch=master#d2e7b803d6d788e461c38da45ce19feaca9513ff"
+source = "git+https://github.com/ActivityWatch/aw-server-rust.git?branch=master#df9c4fababf90e73488b90a4073c14ea02ae2a6b"
 dependencies = [
  "aw-models",
  "chrono",
@@ -388,7 +388,7 @@ dependencies = [
 [[package]]
 name = "aw-datastore"
 version = "0.1.0"
-source = "git+https://github.com/ActivityWatch/aw-server-rust.git?branch=master#d2e7b803d6d788e461c38da45ce19feaca9513ff"
+source = "git+https://github.com/ActivityWatch/aw-server-rust.git?branch=master#df9c4fababf90e73488b90a4073c14ea02ae2a6b"
 dependencies = [
  "aw-models",
  "aw-transform",
@@ -405,7 +405,7 @@ dependencies = [
 [[package]]
 name = "aw-models"
 version = "0.1.0"
-source = "git+https://github.com/ActivityWatch/aw-server-rust.git?branch=master#d2e7b803d6d788e461c38da45ce19feaca9513ff"
+source = "git+https://github.com/ActivityWatch/aw-server-rust.git?branch=master#df9c4fababf90e73488b90a4073c14ea02ae2a6b"
 dependencies = [
  "chrono",
  "log",
@@ -417,7 +417,7 @@ dependencies = [
 [[package]]
 name = "aw-query"
 version = "0.1.0"
-source = "git+https://github.com/ActivityWatch/aw-server-rust.git?branch=master#d2e7b803d6d788e461c38da45ce19feaca9513ff"
+source = "git+https://github.com/ActivityWatch/aw-server-rust.git?branch=master#df9c4fababf90e73488b90a4073c14ea02ae2a6b"
 dependencies = [
  "aw-datastore",
  "aw-models",
@@ -433,7 +433,7 @@ dependencies = [
 [[package]]
 name = "aw-server"
 version = "0.14.0"
-source = "git+https://github.com/ActivityWatch/aw-server-rust.git?branch=master#d2e7b803d6d788e461c38da45ce19feaca9513ff"
+source = "git+https://github.com/ActivityWatch/aw-server-rust.git?branch=master#df9c4fababf90e73488b90a4073c14ea02ae2a6b"
 dependencies = [
  "android_logger",
  "aw-client-rust",
@@ -510,7 +510,7 @@ dependencies = [
 [[package]]
 name = "aw-transform"
 version = "0.1.0"
-source = "git+https://github.com/ActivityWatch/aw-server-rust.git?branch=master#d2e7b803d6d788e461c38da45ce19feaca9513ff"
+source = "git+https://github.com/ActivityWatch/aw-server-rust.git?branch=master#df9c4fababf90e73488b90a4073c14ea02ae2a6b"
 dependencies = [
  "aw-models",
  "chrono",
@@ -873,7 +873,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -3486,7 +3486,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -4985,7 +4985,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b1fdf65dd6331831494dd616b30351c38e96e45921a27745cf98490458b90bb"
 dependencies = [
- "dirs 6.0.0",
+ "dirs 4.0.0",
 ]
 
 [[package]]
@@ -5739,7 +5739,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0136791f7c95b1f6dd99f9cc786b91bb81c3800b639b3478e561ddb7be95e5f1"
 dependencies = [
  "fastrand",
- "getrandom 0.4.1",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -6684,7 +6684,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -22,7 +22,7 @@ tauri-build = { version = "2.0.5", features = [] }
 [dependencies]
 clap = { version = "4", features = ["derive"] }
 shell-words = "1.1.0"
-tauri = { version = "2.2.2", features = ["tray-icon"] }
+tauri = { version = "2.2.5", features = ["tray-icon"] }
 tauri-plugin-shell = "2.2.0"
 tauri-plugin-dialog = "2.2.0"
 tauri-plugin-notification = "2.2.1"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -33,7 +33,7 @@ tauri-plugin-updater = "2"
 tauri-plugin-opener = "2"
 
 tokio = { version = "1", features = ["rt-multi-thread"] }
-notify = "8.0.0"
+notify = "8.2.0"
 notify-rust = "4.12.0"
 dirs = "5.0.1"
 serde = { version = "1.0.217", features = ["derive"] }


### PR DESCRIPTION
Combines open Dependabot PRs for `/src-tauri`:

- #90: `build(deps): bump tauri from 2.2.2 to 2.2.5 in /src-tauri`
- #153: `build(deps): bump notify from 8.0.0 to 8.2.0 in /src-tauri`
- #250: `build(deps): bump chrono from 0.4.43 to 0.4.45 in /src-tauri`
- #254: `build(deps): bump the aw-server-rust group in /src-tauri with 2 updates`
- #255: `build(deps): bump open from 5.3.3 to 5.4.3 in /src-tauri`

Closes #90
Closes #153
Closes #250
Closes #254
Closes #255